### PR TITLE
Use only numeric versions in Git, ignore other tags with the same prefix

### DIFF
--- a/src/git/from_vcs.py
+++ b/src/git/from_vcs.py
@@ -26,7 +26,7 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     # if there isn't one, this yields HEX[-dirty] (no NUM)
     describe_out = run_command(GITS, ["describe", "--tags", "--dirty",
                                       "--always", "--long",
-                                      "--match", "%s*" % tag_prefix],
+                                      "--match", "%s[[:digit:]]*" % tag_prefix],
                                cwd=root)
     # --long was added in git-1.5.5
     if describe_out is None:


### PR DESCRIPTION
I want to use simplified version tags in my projects: either "1.2.3rc" or "v1.2.3rc" (as in gevent), i.e. with no special long prefixes, such as "mylibrary-".

In current versioneer implementation, it would conflict with other tags that start with "v" (if prefix is set to "v") or with all tags (if prefix is an empty string).

Obviously, versions that start with non-digit either are very rare or do no exist at all; versions always start with a number.

So, by setting the prefix to "v", I expect that only tags like "v1.2.3rc" will be used, while tags like "vararg-experiment" or "vasilyev-patch" would not be treated as version tags (assuming that no other helper tags look like "v[digit]...").

Similarly, when I set the tag prefix to an empty string, I expect that "1.2.3rc1" would be treated as a version, while "here-it-happened-2" would not.

Now, "vasilyev-patch" leads to a version "asilyev-patch+28.gxxxxxxxx", and "here-it-happened-2" leads to a version "here-it-happened-2+28.gxxxxxxxx". And you cannot use lightweight tags for such temporary things, because "--tags" option is used in versioneer.

As tag patterns are passed to `git describe --match`, and it accepts glob(7) patterns, my suggestion is to fix this line to expect at least one digit after the prefix; all other logic with prefix removal stays the same, the digit itself goes to the version number as usually. If needed, additional option can be added for those very rare cases when version is not numeric — I can't imaging this, though, so this is not needed yet.

PS: Not sure how to add tests for this properly.
