### PR TITLE
Canonicalize pep440-pre style

### DIFF
--- a/details.md
+++ b/details.md
@@ -71,7 +71,7 @@ The renderer function is controlled by a configuration value called `style`. You
 | ---            | ----------- |
 | `default`      | same as `pep440` |
 | `pep440`       | `TAG[+DISTANCE.gSHORTHASH[.dirty]]`, a PEP-440 compatible version string which uses the "local version identifier" to record the complete non-tag information. This format provides compliant versions even under unusual/error circumstances. It returns `0+untagged.DISTANCE.gHASH[.dirty]` before any tags have been set, `0+unknown` if the tree does not contain enough information to report a version (e.g. the .git directory has been removed), and `0.unparseable[.dirty]` if `git describe` emits something weird. If TAG includes a plus sign, then this will use a dot as a separator instead (`TAG[.DISTANCE.gSHORTHASH[.dirty]]`).|
-| `pep440-pre`   | `TAG[.post.devDISTANCE]`, a PEP-440 compatible version string which loses information but has the useful property that non-tagged versions qualify for `pip install --pre` (by virtue of the `.dev` component). This form does not record the commit hash, nor the `-dirty` flag. |
+| `pep440-pre`   | `TAG[.post0.devDISTANCE]`, a PEP-440 compatible version string which loses information but has the useful property that non-tagged versions qualify for `pip install --pre` (by virtue of the `.dev` component). This form does not record the commit hash, nor the `-dirty` flag. |
 | `pep440-post`  | `TAG[.postDISTANCE[.dev0]+gSHORTHASH]`, a PEP-440 compatible version string which allows all commits to get installable versions, and retains the commit hash.
 | `pep440-old`   | `TAG[.postDISTANCE[.dev0]]`, a PEP-440 compatible version string which loses information but enables downstream projects to depend upon post-release versions (by counting commits). The ".dev0" suffix indicates a dirty tree. This form does not record the commit hash. If nothing has been tagged, this will be `0.postDISTANCE[.dev0]`. Note that PEP-0440 rules indicate that `X.dev0` sorts as "older" than `X`, so our -dirty flag is expressed somewhat backwards (usually "dirty" indicates newer changes than the base commit), but PEP-0440 offers no positive post-".postN" component. You should never be releasing software with -dirty anyways. |
 | `git-describe` | `TAG[-DISTANCE-gSHORTHASH][-dirty]`, equivalent to `git describe --tags --dirty --always`. The distance and shorthash are only included if the commit is not tagged. If nothing was tagged, this will be the short revisionid, plus "-dirty" if dirty. |
@@ -101,10 +101,10 @@ The from-keywords mode will only produce `exact-tag` and `full-revisionid`. If t
 
 (note: this is not yet accurate)
 
-| key          | file               | keywords          | git-describe             | parentdir |
-| ---          | ------------------ | ----------------- | ------------------------ | --------- |
-| pep440       | TAG[+DIST.gHASH]   | TAG or 0.unknown? | TAG[+DIST.gHASH[.dirty]] | TAG or ?  |
-| pep440-pre   | TAG[.post.devDIST] | TAG or ?          | TAG[.post.devDIST]       | TAG or ?  |
-| pep440-old   | TAG[.postDIST]     | TAG or ?          | TAG[.postDIST[.dev0]]    | TAG or ?  |
-| git-describe | TAG[-DIST-gHASH]   | TAG or ?          | TAG[-DIST-gHASH][-dirty] | TAG or ?  |
-| long         | TAG-DIST-gHASH     | TAG-gHASH or ?    | TAG-DIST-gHASH[-dirty]   | ?         |
+| key          | file                | keywords          | git-describe             | parentdir |
+| ---          | ------------------- | ----------------- | ------------------------ | --------- |
+| pep440       | TAG[+DIST.gHASH]    | TAG or 0.unknown? | TAG[+DIST.gHASH[.dirty]] | TAG or ?  |
+| pep440-pre   | TAG[.post0.devDIST] | TAG or ?          | TAG[.post0.devDIST]      | TAG or ?  |
+| pep440-old   | TAG[.postDIST]      | TAG or ?          | TAG[.postDIST[.dev0]]    | TAG or ?  |
+| git-describe | TAG[-DIST-gHASH]    | TAG or ?          | TAG[-DIST-gHASH][-dirty] | TAG or ?  |
+| long         | TAG-DIST-gHASH      | TAG-gHASH or ?    | TAG-DIST-gHASH[-dirty]   | ?         |

--- a/src/render.py
+++ b/src/render.py
@@ -32,18 +32,18 @@ def render_pep440(pieces):
 
 
 def render_pep440_pre(pieces):
-    """TAG[.post.devDISTANCE] -- No -dirty.
+    """TAG[.post0.devDISTANCE] -- No -dirty.
 
     Exceptions:
-    1: no tags. 0.post.devDISTANCE
+    1: no tags. 0.post0.devDISTANCE
     """
     if pieces["closest-tag"]:
         rendered = pieces["closest-tag"]
         if pieces["distance"]:
-            rendered += ".post.dev%d" % pieces["distance"]
+            rendered += ".post0.dev%d" % pieces["distance"]
     else:
         # exception #1
-        rendered = "0.post.dev%d" % pieces["distance"]
+        rendered = "0.post0.dev%d" % pieces["distance"]
     return rendered
 
 

--- a/test/git/test_git.py
+++ b/test/git/test_git.py
@@ -156,7 +156,7 @@ closest-tag: 1.0
 distance: 1
 dirty: False
 pep440: 1.0+1.g250b7ca
-pep440-pre: 1.0.post.dev1
+pep440-pre: 1.0.post0.dev1
 pep440-post: 1.0.post1+g250b7ca
 pep440-old: 1.0.post1
 git-describe: 1.0-1-g250b7ca
@@ -166,7 +166,7 @@ closest-tag: 1.0
 distance: 1
 dirty: True
 pep440: 1.0+1.g250b7ca.dirty
-pep440-pre: 1.0.post.dev1
+pep440-pre: 1.0.post0.dev1
 pep440-post: 1.0.post1.dev0+g250b7ca
 pep440-old: 1.0.post1.dev0
 git-describe: 1.0-1-g250b7ca-dirty
@@ -177,7 +177,7 @@ closest-tag: 1.0+plus
 distance: 1
 dirty: False
 pep440: 1.0+plus.1.g250b7ca
-pep440-pre: 1.0+plus.post.dev1
+pep440-pre: 1.0+plus.post0.dev1
 pep440-post: 1.0+plus.post1.g250b7ca
 pep440-old: 1.0+plus.post1
 git-describe: 1.0+plus-1-g250b7ca
@@ -187,7 +187,7 @@ closest-tag: 1.0+plus
 distance: 1
 dirty: True
 pep440: 1.0+plus.1.g250b7ca.dirty
-pep440-pre: 1.0+plus.post.dev1
+pep440-pre: 1.0+plus.post0.dev1
 pep440-post: 1.0+plus.post1.dev0.g250b7ca
 pep440-old: 1.0+plus.post1.dev0
 git-describe: 1.0+plus-1-g250b7ca-dirty
@@ -198,7 +198,7 @@ closest-tag: None
 distance: 1
 dirty: False
 pep440: 0+untagged.1.g250b7ca
-pep440-pre: 0.post.dev1
+pep440-pre: 0.post0.dev1
 pep440-post: 0.post1+g250b7ca
 pep440-old: 0.post1
 git-describe: 250b7ca
@@ -208,7 +208,7 @@ closest-tag: None
 distance: 1
 dirty: True
 pep440: 0+untagged.1.g250b7ca.dirty
-pep440-pre: 0.post.dev1
+pep440-pre: 0.post0.dev1
 pep440-post: 0.post1.dev0+g250b7ca
 pep440-old: 0.post1.dev0
 git-describe: 250b7ca-dirty

--- a/test/test_render.py
+++ b/test/test_render.py
@@ -113,12 +113,12 @@ class Test_pep440_pre(unittest.TestCase, Testing_renderer_case_mixin):
     style = 'pep440-pre'
     expected = {'tagged_0_commits_clean': 'v1.2.3',
                 'tagged_0_commits_dirty': 'v1.2.3',
-                'tagged_1_commits_clean': 'v1.2.3.post.dev1',
-                'tagged_1_commits_dirty': 'v1.2.3.post.dev1',
-                'untagged_0_commits_clean': '0.post.dev0',
-                'untagged_0_commits_dirty': '0.post.dev0',
-                'untagged_1_commits_clean': '0.post.dev1',
-                'untagged_1_commits_dirty': '0.post.dev1',
+                'tagged_1_commits_clean': 'v1.2.3.post0.dev1',
+                'tagged_1_commits_dirty': 'v1.2.3.post0.dev1',
+                'untagged_0_commits_clean': '0.post0.dev0',
+                'untagged_0_commits_dirty': '0.post0.dev0',
+                'untagged_1_commits_clean': '0.post0.dev1',
+                'untagged_1_commits_dirty': '0.post0.dev1',
                 'error_getting_parts': 'unknown'
                 }
 


### PR DESCRIPTION
Fix for #162. Changes `.post.` to its equivalent but canonical form of `.post0.` in `pep440-pre` style. 

Closes #162.