### PR TITLE
Fix tests and deprecation warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ python:
   - "pypy3"
 install:
   - pip install "tox<3.0.0" tox-travis
+  # work around for travis weirdness on Python 3.3
+  # https://github.com/aws/base64io-python/issues/4#issuecomment-397857642
+  - if [[ $TRAVIS_PYTHON_VERSION == 3.3 ]]; then pip install virtualenv==15.2.0; fi
 script:
   - tox
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ python:
   - "pypy"
   - "pypy3"
 install:
-  - pip install tox-travis
+  - pip install "tox<3.0.0" tox-travis
 script:
   - tox
 matrix:

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ def generate_versioneer_py():
     s.write(get("src/subprocess_helper.py", do_strip=True))
 
     for VCS in get_vcs_list():
-        s.write(u("LONG_VERSION_PY['%s'] = '''\n" % VCS))
+        s.write(u("LONG_VERSION_PY['%s'] = r'''\n" % VCS))
         s.write(generate_long_version_py(VCS))
         s.write(u("'''\n"))
         s.write(u("\n\n"))

--- a/test/demoapp-script-only/setup.py
+++ b/test/demoapp-script-only/setup.py
@@ -12,7 +12,7 @@ class my_build_scripts(build_scripts):
         generated = os.path.join(tempdir, "rundemo")
         with open(generated, "wb") as f:
             for line in open("src/rundemo-template", "rb"):
-                if line.strip().decode("ascii") == "#versions":
+                if line.strip().decode("ascii") == "versions = None":
                     f.write(('versions = %r\n' % (versions,)).encode("ascii"))
                 else:
                     f.write(line)

--- a/test/demoapp-script-only/src/rundemo-template
+++ b/test/demoapp-script-only/src/rundemo-template
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-#versions
+versions = None
 
 print("__version__:%s" % versions['version'])
 for k in sorted(versions.keys()):

--- a/test/git/test_git.py
+++ b/test/git/test_git.py
@@ -8,7 +8,7 @@ import unittest
 import tempfile
 
 
-from pkg_resources import parse_version, SetuptoolsLegacyVersion
+from pkg_resources import parse_version
 
 sys.path.insert(0, "src")
 import common
@@ -590,7 +590,8 @@ class Repo(common.Common, unittest.TestCase):
     def assertPEP440(self, got, state, tree, runtime):
         where = "/".join([state, tree, runtime])
         pv = parse_version(got)
-        self.assertFalse(isinstance(pv, SetuptoolsLegacyVersion),
+        # rather than using an undocumented API, setuptools dev recommends this
+        self.assertFalse("Legacy" in pv.__class__.__name__,
                          "%s: '%s' was not pep440-compatible"
                          % (where, got))
         self.assertEqual(str(pv), got,

--- a/tox.ini
+++ b/tox.ini
@@ -20,8 +20,8 @@ deps =
     py27,py33,py34,py35,py36,pypy,pypy3: flake8-docstrings
     wheel
     setuptools
-    py32: virtualenv<14.0.0
-    py26,py27,py33,py34,py35,py36,pypy,pypy3: virtualenv
+    py32,py33: virtualenv<14.0.0
+    py26,py27,py34,py35,py36,pypy,pypy3: virtualenv
     discover
     pep8
 

--- a/tox.ini
+++ b/tox.ini
@@ -9,10 +9,11 @@ skip_missing_interpreters = True
 
 [testenv]
 # virtualenv>=14.0.0 is incompatible with python 3.2
-# flake8>=3.0.0 is incompatible with 2.6,3.2,3.3
+# flake8>=3.0.0 and pyflakes>=2.0.0 are incompatible with 2.6,3.2,3.3
 deps =
-    pyflakes
+    py27,py34,py35,py36,pypy,pypy3: pyflakes
     py26,py32,py33: flake8<3.0.0
+    py26,py32,py33: pyflakes<2.0.0
     py27,py34,py35,py36,pypy,pypy3: flake8
     py26,py32: pydocstyle<2
     py26,py32: flake8-docstrings<1.1.0


### PR DESCRIPTION
Tests are currently broken in master, this PR fixes that.

Most of the work was making sure that installed packages used for testing were old enough to work with EOL'd versions of Python.