### PR TITLE
Fix mention to Styles section

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,7 +4,7 @@ First, decide on values for the following configuration variables:
 
 * `VCS`: the version control system you use. Currently accepts "git".
 
-* `style`: the style of version string to be produced. See "Styles" below for
+* `style`: the style of version string to be produced. See [Styles](https://github.com/warner/python-versioneer/blob/master/README.md#styles) for
   details. Defaults to "pep440", which looks like
   `TAG[+DISTANCE.gSHORTHASH[.dirty]]`.
 


### PR DESCRIPTION
In `style` section there is a mention to the Styles section "below", where the section is actually in a different file. The commit changes the sentence and introduces a link to the correct document and section.