### PR TITLE
Fix tests, deprecation warnings, test only on live Pythons

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ python:
   - "pypy3"
 install:
   - pip install "tox<3.0.0" tox-travis
+  # work around for travis weirdness on Python 3.3
+  # https://github.com/aws/base64io-python/issues/4#issuecomment-397857642
+  - if [[ $TRAVIS_PYTHON_VERSION == 3.3 ]]; then pip install virtualenv==15.2.0; fi
 script:
   - tox
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,28 @@
-sudo: false
+os: linux
+arch: amd64
+dist: bionic
 language: python
 cache: pip
 before_cache:
   - rm -f $HOME/.cache/pip/log/debug.log
+
 branches:
   except:
     - /^WIP-.*$/
+
 python:
-  - "2.6"
-  - "2.7"
-  - "3.2"
-  - "3.3"
-  - "3.4"
-  - "3.5"
-  - "3.6"
-  - "pypy"
-  - "pypy3"
+  - 3.6
+  - 3.7
+  - 3.8
+  - pypy
+  - pypy3
+
 install:
   - pip install "tox<3.0.0" tox-travis
-  # work around for travis weirdness on Python 3.3
-  # https://github.com/aws/base64io-python/issues/4#issuecomment-397857642
-  - if [[ $TRAVIS_PYTHON_VERSION == 3.3 ]]; then pip install virtualenv==15.2.0; fi
+
 script:
   - tox
-matrix:
+
+jobs:
   allow_failures:
-    - python: "pypy3"
+    - python: pypy3

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ python:
   - "pypy"
   - "pypy3"
 install:
-  - pip install tox-travis
+  - pip install "tox<3.0.0" tox-travis
 script:
   - tox
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,11 @@ python:
   - 3.6
   - 3.7
   - 3.8
-  - pypy
+  - pypy2
   - pypy3
 
 install:
-  - pip install "tox<3.0.0" tox-travis
+  - pip install tox-travis
 
 script:
   - tox

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ def generate_versioneer_py():
     s.write(get("src/subprocess_helper.py", do_strip=True))
 
     for VCS in get_vcs_list():
-        s.write(u("LONG_VERSION_PY['%s'] = '''\n" % VCS))
+        s.write(u("LONG_VERSION_PY['%s'] = r'''\n" % VCS))
         s.write(generate_long_version_py(VCS))
         s.write(u("'''\n"))
         s.write(u("\n\n"))

--- a/test/demoapp-script-only/setup.py
+++ b/test/demoapp-script-only/setup.py
@@ -12,7 +12,7 @@ class my_build_scripts(build_scripts):
         generated = os.path.join(tempdir, "rundemo")
         with open(generated, "wb") as f:
             for line in open("src/rundemo-template", "rb"):
-                if line.strip().decode("ascii") == "#versions":
+                if line.strip().decode("ascii") == "versions = None":
                     f.write(('versions = %r\n' % (versions,)).encode("ascii"))
                 else:
                     f.write(line)

--- a/test/demoapp-script-only/src/rundemo-template
+++ b/test/demoapp-script-only/src/rundemo-template
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-#versions
+versions = None
 
 print("__version__:%s" % versions['version'])
 for k in sorted(versions.keys()):

--- a/test/git/test_git.py
+++ b/test/git/test_git.py
@@ -8,7 +8,7 @@ import unittest
 import tempfile
 
 
-from pkg_resources import parse_version, SetuptoolsLegacyVersion
+from pkg_resources import parse_version
 
 sys.path.insert(0, "src")
 import common
@@ -590,7 +590,8 @@ class Repo(common.Common, unittest.TestCase):
     def assertPEP440(self, got, state, tree, runtime):
         where = "/".join([state, tree, runtime])
         pv = parse_version(got)
-        self.assertFalse(isinstance(pv, SetuptoolsLegacyVersion),
+        # rather than using an undocumented API, setuptools dev recommends this
+        self.assertFalse("Legacy" in pv.__class__.__name__,
                          "%s: '%s' was not pep440-compatible"
                          % (where, got))
         self.assertEqual(str(pv), got,

--- a/tox.ini
+++ b/tox.ini
@@ -20,8 +20,8 @@ deps =
     py27,py33,py34,py35,py36,pypy,pypy3: flake8-docstrings
     wheel
     setuptools
-    py32: virtualenv<14.0.0
-    py26,py27,py33,py34,py35,py36,pypy,pypy3: virtualenv
+    py32,py33: virtualenv<14.0.0
+    py26,py27,py34,py35,py36,pypy,pypy3: virtualenv
     discover
     pep8
 

--- a/tox.ini
+++ b/tox.ini
@@ -9,10 +9,11 @@ skip_missing_interpreters = True
 
 [testenv]
 # virtualenv>=14.0.0 is incompatible with python 3.2
-# flake8>=3.0.0 is incompatible with 2.6,3.2,3.3
+# flake8>=3.0.0 and pyflakes>=2.0.0 are incompatible with 2.6,3.2,3.3
 deps =
-    pyflakes
+    py27,py34,py35,py36,pypy,pypy3: pyflakes
     py26,py32,py33: flake8<3.0.0
+    py26,py32,py33: pyflakes<2.0.0
     py27,py34,py35,py36,pypy,pypy3: flake8
     py26,py32: pydocstyle<2
     py26,py32: flake8-docstrings<1.1.0

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py36,py37,py38,pypy,pypy3
+envlist = py36,py37,py38,pypy2,pypy3
 skip_missing_interpreters = True
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -4,25 +4,19 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26,py27,py32,py33,py34,py35,py36,pypy,pypy3
+envlist = py36,py37,py38,pypy,pypy3
 skip_missing_interpreters = True
 
 [testenv]
 # virtualenv>=14.0.0 is incompatible with python 3.2
 # flake8>=3.0.0 and pyflakes>=2.0.0 are incompatible with 2.6,3.2,3.3
 deps =
-    py27,py34,py35,py36,pypy,pypy3: pyflakes
-    py26,py32,py33: flake8<3.0.0
-    py26,py32,py33: pyflakes<2.0.0
-    py27,py34,py35,py36,pypy,pypy3: flake8
-    py26,py32: pydocstyle<2
-    py26,py32: flake8-docstrings<1.1.0
-    py27,py33,py34,py35,py36,pypy,pypy3: flake8-docstrings
+    pyflakes
+    flake8
+    flake8-docstrings
     wheel
     setuptools
-    py32,py33: virtualenv<14.0.0
-    py26,py27,py34,py35,py36,pypy,pypy3: virtualenv
-    discover
+    virtualenv<20
     pep8
 
 commands =
@@ -33,7 +27,7 @@ commands =
     # this creates versioneer.py in the current directory, which is used by
     # tests
     python setup.py make_versioneer
-    python -m discover test
+    python -m unittest discover test
     python test/git/test_git.py -v
     python test/git/test_invocations.py -v
 


### PR DESCRIPTION
Builds on #190.

This PR drops Python <3.6 support altogether. This may require some discussion. If we want to support older versions for a bit, I think the main things we'll need to do are to keep the `virtualenv<20` restriction (relaxing that was too big a job for this PR) and pick Travis `dist`s that support those versions of Python.

Closes #190.