### PR TITLE
RF/DOC: Miscellaneous cleanups and documentation improvements

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,7 +15,7 @@ First, decide on values for the following configuration variables:
   `__init__.py` file, so it can be imported at runtime. If your project uses
   `src/myproject/__init__.py`, this should be `src/myproject/_version.py`.
   This file should be checked in to your VCS as usual: the copy created below
-  by `setup.py setup_versioneer` will include code that parses expanded VCS
+  by `versioneer install` will include code that parses expanded VCS
   keywords in generated tarballs. The 'build' and 'sdist' commands will
   replace it with a copy that has just the calculated version string.
 
@@ -23,7 +23,7 @@ First, decide on values for the following configuration variables:
   therefore never import `_version.py`), since "setup.py sdist" -based trees
   still need somewhere to record the pre-calculated version strings. Anywhere
   in the source tree should do. If there is a `__init__.py` next to your
-  `_version.py`, the `setup.py setup_versioneer` command (described below)
+  `_version.py`, the `versioneer install` command (described below)
   will append some `__version__`-setting assignments, if they aren't already
   present.
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,10 @@ system, and maybe making new tarballs.
 
 ## Quick Install
 
-* `pip install versioneer` to somewhere to your $PATH
-* add a `[versioneer]` section to your setup.cfg (see below)
+* `pip install versioneer` to somewhere in your $PATH
+* add a `[versioneer]` section to your setup.cfg (see [Install](INSTALL.md))
 * run `versioneer install` in your source tree, commit the results
+* Verify version information with `python setup.py version`
 
 ## Version Identifiers
 

--- a/README.md
+++ b/README.md
@@ -220,18 +220,6 @@ a different virtualenv), so this can be surprising.
 this one, but upgrading to a newer version of setuptools should probably
 resolve it.
 
-### Unicode version strings
-
-While Versioneer works (and is continually tested) with both Python 2 and
-Python 3, it is not entirely consistent with bytes-vs-unicode distinctions.
-Newer releases probably generate unicode version strings on py2. It's not
-clear that this is wrong, but it may be surprising for applications when then
-write these strings to a network connection or include them in bytes-oriented
-APIs like cryptographic checksums.
-
-[Bug #71](https://github.com/python-versioneer/python-versioneer/issues/71) investigates
-this question.
-
 
 ## Updating Versioneer
 

--- a/test/git/test_git.py
+++ b/test/git/test_git.py
@@ -522,9 +522,8 @@ class Repo(common.Common, unittest.TestCase):
         self.git("archive", "--format=tar", "--prefix=demoapp-TD/",
                  "--output=../demo.tar", "HEAD")
         os.mkdir(self.subpath("out/TD"))
-        t = tarfile.TarFile(self.subpath("demo.tar"))
-        t.extractall(path=self.subpath("out/TD"))
-        t.close()
+        with tarfile.TarFile(self.subpath("demo.tar")) as t:
+            t.extractall(path=self.subpath("out/TD"))
         self.check_version(os.path.join(target, self.project_sub_dir),
                            state, "TD", exps["TD"])
 
@@ -539,9 +538,8 @@ class Repo(common.Common, unittest.TestCase):
         self.assertEqual(distfile, "demo-%s.tar" % exps["TE"][0])
         fn = os.path.join(dist_path, distfile)
         os.mkdir(self.subpath("out/TE"))
-        t = tarfile.TarFile(fn)
-        t.extractall(path=self.subpath("out/TE"))
-        t.close()
+        with tarfile.TarFile(fn) as t:
+            t.extractall(path=self.subpath("out/TE"))
         target = self.subpath("out/TE/demo-%s" % exps["TE"][0])
         self.assertTrue(os.path.isdir(target))
         self.check_version(target, state, "TE", exps["TE"])

--- a/test/git/test_invocations.py
+++ b/test/git/test_invocations.py
@@ -209,9 +209,8 @@ class _Invocations(common.Common):
         if os.path.exists(unpack_into):
             shutil.rmtree(unpack_into)
         os.mkdir(unpack_into)
-        t = tarfile.TarFile(sdist)
-        t.extractall(path=unpack_into)
-        t.close()
+        with tarfile.TarFile(sdist) as t:
+            t.extractall(path=unpack_into)
         unpacked = os.path.join(unpack_into, "demoapp2-2.0")
         self.assertTrue(os.path.exists(unpacked))
         return unpacked
@@ -222,9 +221,8 @@ class _Invocations(common.Common):
         if os.path.exists(unpack_into):
             shutil.rmtree(unpack_into)
         os.mkdir(unpack_into)
-        t = tarfile.TarFile(sdist)
-        t.extractall(path=unpack_into)
-        t.close()
+        with tarfile.TarFile(sdist) as t:
+            t.extractall(path=unpack_into)
         unpacked = os.path.join(unpack_into, "demoapp2-2.0")
         self.assertTrue(os.path.exists(unpacked))
         return unpacked
@@ -249,9 +247,8 @@ class _Invocations(common.Common):
         if os.path.exists(unpack_into):
             shutil.rmtree(unpack_into)
         os.mkdir(unpack_into)
-        t = tarfile.TarFile(sdist)
-        t.extractall(path=unpack_into)
-        t.close()
+        with tarfile.TarFile(sdist) as t:
+            t.extractall(path=unpack_into)
         unpacked = os.path.join(unpack_into, "demoappext-2.0")
         self.assertTrue(os.path.exists(unpacked))
         return unpacked
@@ -330,9 +327,8 @@ class _Invocations(common.Common):
         if os.path.exists(unpack_into):
             shutil.rmtree(unpack_into)
         os.mkdir(unpack_into)
-        t = tarfile.TarFile(sdist)
-        t.extractall(path=unpack_into)
-        t.close()
+        with tarfile.TarFile(sdist) as t:
+            t.extractall(path=unpack_into)
         unpacked = os.path.join(unpack_into, "demoapp2-2.0")
         self.assertTrue(os.path.exists(unpacked))
         return unpacked
@@ -343,9 +339,8 @@ class _Invocations(common.Common):
         if os.path.exists(unpack_into):
             shutil.rmtree(unpack_into)
         os.mkdir(unpack_into)
-        t = tarfile.TarFile(sdist)
-        t.extractall(path=unpack_into)
-        t.close()
+        with tarfile.TarFile(sdist) as t:
+            t.extractall(path=unpack_into)
         unpacked = os.path.join(unpack_into, "demoapp2-2.0")
         self.assertTrue(os.path.exists(unpacked))
         return unpacked
@@ -434,19 +429,17 @@ class DistutilsRepo(_Invocations, unittest.TestCase):
 
     def test_sdist(self):
         sdist = self.make_distutils_sdist() # asserts version as a side-effect
-        t = tarfile.TarFile(sdist)
         # make sure we used distutils/sdist, not setuptools/sdist
-        self.assertFalse("demoapp2-2.0/src/demoapp2.egg-info/PKG-INFO" in
-                         t.getnames())
-        t.close()
+        with tarfile.TarFile(sdist) as t:
+            self.assertFalse("demoapp2-2.0/src/demoapp2.egg-info/PKG-INFO" in
+                             t.getnames())
 
     def test_sdist_subproject(self):
         sdist = self.make_distutils_sdist_subproject()
-        t = tarfile.TarFile(sdist)
         # make sure we used distutils/sdist, not setuptools/sdist
-        self.assertFalse("demoapp2-2.0/src/demoapp2.egg-info/PKG-INFO" in
-                         t.getnames())
-        t.close()
+        with tarfile.TarFile(sdist) as t:
+            self.assertFalse("demoapp2-2.0/src/demoapp2.egg-info/PKG-INFO" in
+                             t.getnames())
 
     def test_pip_install(self):
         repodir = self.make_distutils_repo()
@@ -569,19 +562,17 @@ class SetuptoolsRepo(_Invocations, unittest.TestCase):
 
     def test_sdist(self):
         sdist = self.make_setuptools_sdist() # asserts version as a side-effect
-        t = tarfile.TarFile(sdist)
         # make sure we used setuptools/sdist, not distutils/sdist
-        self.assertTrue("demoapp2-2.0/src/demoapp2.egg-info/PKG-INFO" in
-                        t.getnames())
-        t.close()
+        with tarfile.TarFile(sdist) as t:
+            self.assertTrue("demoapp2-2.0/src/demoapp2.egg-info/PKG-INFO" in
+                            t.getnames())
 
     def test_sdist_subproject(self):
         sdist = self.make_setuptools_sdist_subproject()
-        t = tarfile.TarFile(sdist)
         # make sure we used setuptools/sdist, not distutils/sdist
-        self.assertTrue("demoapp2-2.0/src/demoapp2.egg-info/PKG-INFO" in
-                        t.getnames())
-        t.close()
+        with tarfile.TarFile(sdist) as t:
+            self.assertTrue("demoapp2-2.0/src/demoapp2.egg-info/PKG-INFO" in
+                            t.getnames())
 
     def test_pip_install(self):
         linkdir = self.make_linkdir()

--- a/test/git/test_invocations.py
+++ b/test/git/test_invocations.py
@@ -564,15 +564,13 @@ class SetuptoolsRepo(_Invocations, unittest.TestCase):
         sdist = self.make_setuptools_sdist() # asserts version as a side-effect
         # make sure we used setuptools/sdist, not distutils/sdist
         with tarfile.TarFile(sdist) as t:
-            self.assertTrue("demoapp2-2.0/src/demoapp2.egg-info/PKG-INFO" in
-                            t.getnames())
+            self.assertIn("demoapp2-2.0/src/demoapp2.egg-info/PKG-INFO", t.getnames())
 
     def test_sdist_subproject(self):
         sdist = self.make_setuptools_sdist_subproject()
         # make sure we used setuptools/sdist, not distutils/sdist
         with tarfile.TarFile(sdist) as t:
-            self.assertTrue("demoapp2-2.0/src/demoapp2.egg-info/PKG-INFO" in
-                            t.getnames())
+            self.assertIn("demoapp2-2.0/src/demoapp2.egg-info/PKG-INFO", t.getnames())
 
     def test_pip_install(self):
         linkdir = self.make_linkdir()


### PR DESCRIPTION
Closes #113.

> - remove the hacks/stand-ins for `unittest.skip` and `unittest.expectedFailure` in test_invocations.py

Done in #216.

> - maybe use --isolated everywhere (test_invocations.py)

Did not attempt.

> - use `with TarFile(Sdist) as t` in `test_sdist` (test_invocations.py)
> - switch to `assertNotIn`/`assertIn` (test_invocations.py)

Done in this PR.

---

Also closes #62. The Python-3.6-ification did not fully take in setup.py.

---

Closes #169 
Closes #198 
Closes #204