### PR TITLE
FIX: Construct binary wheel filenames consistently for Python and Pypy

### DIFF
--- a/test/git/test_invocations.py
+++ b/test/git/test_invocations.py
@@ -59,6 +59,9 @@ class _Invocations(common.Common):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             virtualenv.create_environment(venv_dir)
+            self.run_in_venv(venv_dir, venv_dir,
+                             'pip', 'install', '-U',
+                             'pip', 'wheel', 'packaging')
         return venv_dir
 
     def run_in_venv(self, venv, workdir, command, *args):
@@ -845,9 +848,8 @@ class SetuptoolsUnpacked(_Invocations, unittest.TestCase):
             os.unlink(demoappext_setuptools_wheel)
         repodir = self.make_setuptools_extension_repo()
         self.python("setup.py", "bdist_wheel", workdir=repodir)
-        wheelhouse = os.path.join(repodir, "dist")
-        created = os.path.join(wheelhouse, wheelname)
-        self.assertIn(created, glob(os.path.join(wheelhouse, "*.whl")))
+        created = os.path.join(repodir, "dist", wheelname)
+        self.assertTrue(os.path.exists(created))
 
     def test_extension_inplace(self):
         # build extensions in place. No wheel package
@@ -876,9 +878,8 @@ class SetuptoolsUnpacked(_Invocations, unittest.TestCase):
                          "pip", "wheel", "--wheel-dir", "wheelhouse",
                          "--no-index", "--find-links", linkdir,
                          ".")
-        wheelhouse = os.path.join(unpacked, "wheelhouse")
-        created = os.path.join(wheelhouse, wheelname)
-        self.assertIn(created, glob(os.path.join(wheelhouse, "*.whl")))
+        created = os.path.join(unpacked, "wheelhouse", wheelname)
+        self.assertTrue(os.path.exists(created))
 
 
 if __name__ == '__main__':

--- a/test/git/test_invocations.py
+++ b/test/git/test_invocations.py
@@ -1,5 +1,4 @@
 import os, sys, shutil, unittest, tempfile, tarfile, virtualenv, warnings
-from glob import glob
 from wheel.bdist_wheel import get_abi_tag, get_platform
 from packaging.tags import interpreter_name, interpreter_version
 

--- a/test/git/test_invocations.py
+++ b/test/git/test_invocations.py
@@ -1,4 +1,5 @@
 import os, sys, shutil, unittest, tempfile, tarfile, virtualenv, warnings
+from glob import glob
 from wheel.bdist_wheel import get_abi_tag, get_platform
 from packaging.tags import interpreter_name, interpreter_version
 
@@ -844,8 +845,9 @@ class SetuptoolsUnpacked(_Invocations, unittest.TestCase):
             os.unlink(demoappext_setuptools_wheel)
         repodir = self.make_setuptools_extension_repo()
         self.python("setup.py", "bdist_wheel", workdir=repodir)
-        created = os.path.join(repodir, "dist", wheelname)
-        self.assertTrue(os.path.exists(created), created)
+        wheelhouse = os.path.join(repodir, "dist")
+        created = os.path.join(wheelhouse, wheelname)
+        self.assertIn(created, glob(os.path.join(wheelhouse, "*.whl")))
 
     def test_extension_inplace(self):
         # build extensions in place. No wheel package
@@ -874,8 +876,9 @@ class SetuptoolsUnpacked(_Invocations, unittest.TestCase):
                          "pip", "wheel", "--wheel-dir", "wheelhouse",
                          "--no-index", "--find-links", linkdir,
                          ".")
-        created = os.path.join(unpacked, "wheelhouse", wheelname)
-        self.assertTrue(os.path.exists(created), created)
+        wheelhouse = os.path.join(unpacked, "wheelhouse")
+        created = os.path.join(wheelhouse, wheelname)
+        self.assertIn(created, glob(os.path.join(wheelhouse, "*.whl")))
 
 
 if __name__ == '__main__':

--- a/test/git/test_invocations.py
+++ b/test/git/test_invocations.py
@@ -848,7 +848,7 @@ class SetuptoolsUnpacked(_Invocations, unittest.TestCase):
         repodir = self.make_setuptools_extension_repo()
         self.python("setup.py", "bdist_wheel", workdir=repodir)
         created = os.path.join(repodir, "dist", wheelname)
-        self.assertTrue(os.path.exists(created))
+        self.assertTrue(os.path.exists(created), created)
 
     def test_extension_inplace(self):
         # build extensions in place. No wheel package
@@ -878,7 +878,7 @@ class SetuptoolsUnpacked(_Invocations, unittest.TestCase):
                          "--no-index", "--find-links", linkdir,
                          ".")
         created = os.path.join(unpacked, "wheelhouse", wheelname)
-        self.assertTrue(os.path.exists(created))
+        self.assertTrue(os.path.exists(created), created)
 
 
 if __name__ == '__main__':

--- a/test/git/test_invocations.py
+++ b/test/git/test_invocations.py
@@ -397,7 +397,7 @@ class _Invocations(common.Common):
 
     def make_binary_wheelname(self, app):
         return "%s-2.0-%s-%s-%s.whl" % (app,
-            "".join([impl, impl_ver]), abi, plat)
+            "".join([impl, impl_ver]), abi, plat.replace("-", "_"))
 
 
 class DistutilsRepo(_Invocations, unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ deps =
     flake8
     flake8-docstrings
     wheel
-    setuptools
+    setuptools>50
     virtualenv<20
     packaging>20
 

--- a/tox.ini
+++ b/tox.ini
@@ -15,9 +15,10 @@ deps =
     flake8
     flake8-docstrings
     wheel
-    setuptools>50
+    setuptools
     virtualenv<20
-    packaging>20
+    packaging>=20
+    pip>=20
 
 commands =
     pip --version

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ deps =
     flake8
     flake8-docstrings
     wheel
-    setuptools
+    setuptools>=50
     virtualenv<20
     packaging>=20
     pip>=20

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ max-line-length = 88
 deps =
     flake8
     flake8-docstrings
-    wheel
+    wheel>=0.35
     setuptools>=50
     virtualenv<20
     packaging>=20

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ deps =
     wheel
     setuptools
     virtualenv<20
-    packaging
+    packaging>20
 
 commands =
     pip --version


### PR DESCRIPTION
Continued from #223

Fix PyPy binary wheel names and tests.