### PR TITLE
REL: 0.19

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,4 @@
+Christopher J. Markiewicz <effigies@gmail.com>
+Christopher J. Markiewicz <effigies@gmail.com> <markiewicz@stanford.edu>
+Panos <zuboci@yandex.com>
+Panos <zuboci@yandex.com> <pkittenis@users.noreply.github.com>

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ python:
   - 3.6
   - 3.7
   - 3.8
-  - 3.9-dev
+  - 3.9
   - pypy3
 
 install:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,18 @@
+## Release 0.19 (TBD)
+
+Versioneer's 0.19 release is the first under new maintainership, and most of the work
+done has been maintenance along with a few features and bug fixes. No significant
+changes to the mode of operation have been included here.
+
+The current maintainers are Nathan Buckner, Yaroslav Halchenko, Chris Markiewicz,
+Kevin Sheppard and Brian Warner.
+
+* Drop support for Python < 3.6, test up to Python 3.9
+* Strip GPG signature information from date (#222)
+* Add `bdist_ext` cmdclass, to support native code extensions (#171)
+* Canonicalize pep440-pre style (#163)
+* Take arguments to `get_cmdclass`
+
 ## Release 0.18 (01-Jan-2017)
 
 * switch to entrypoints to get the right executable suffix on windows (#131)

--- a/README.md
+++ b/README.md
@@ -247,8 +247,10 @@ number of intermediate scripts.
 
 ## Similar projects
 
-* [setuptools_scm](https://github.com/pypa/setuptools_scm/) - a non-vendored build-time dependency
-* [minver](https://github.com/jbweston/miniver) - a lightweight reimplementation of versioneer
+* [setuptools_scm](https://github.com/pypa/setuptools_scm/) - a non-vendored build-time
+  dependency
+* [minver](https://github.com/jbweston/miniver) - a lightweight reimplementation of
+  versioneer
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -245,6 +245,10 @@ installation by editing setup.py . Alternatively, it might go the other
 direction and include code from all supported VCS systems, reducing the
 number of intermediate scripts.
 
+## Similar projects
+
+* [setuptools_scm](https://github.com/pypa/setuptools_scm/) - a non-vendored build-time dependency
+* [minver](https://github.com/jbweston/miniver) - a lightweight reimplementation of versioneer
 
 ## License
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,7 +6,7 @@ when upgrading from an older release, you must make changes in your
 project.
 
 
-## Upgrading to 0.16 or 0.17 or 0.18
+## Upgrading to 0.16, 0.17, 0.18 or 0.19
 
 Nothing special.
 

--- a/setup.py
+++ b/setup.py
@@ -2,15 +2,12 @@
 
 import os, base64, tempfile, io
 from os import path
+from pathlib import Path
 from setuptools import setup, Command
 from setuptools.command.build_py import build_py
 from setuptools.dist import Distribution as _Distribution
 
-LONG="""
-Versioneer is a tool to automatically update version strings (in setup.py and
-the conventional 'from PROJECT import _version' pattern) by asking your
-version-control system about the current tree.
-"""
+LONG = Path.read_text(Path(__file__).parent / "README.md")
 
 # as nice as it'd be to versioneer ourselves, that sounds messy.
 VERSION = "0.19"
@@ -159,7 +156,8 @@ setup(
             'versioneer = versioneer:main',
         ],
     },
-    long_description = LONG,
+    long_description=LONG,
+    long_description_content_type="text/markdown",
     distclass=Distribution,
     cmdclass = { "build_py": my_build_py,
                  "make_versioneer": make_versioneer,

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ version-control system about the current tree.
 """
 
 # as nice as it'd be to versioneer ourselves, that sounds messy.
-VERSION = "0.19.dev0"
+VERSION = "0.19"
 
 
 def ver(s):


### PR DESCRIPTION
I think this repository is in good shape to have a release, with Pythons 3.6-3.9 tested.

This PR does a little last minute cleanup, bumps the version, and uses the `README.md` as the PyPI description.

I'd appreciate a review and look over recent changes: https://github.com/python-versioneer/python-versioneer/compare/0.18...rel/0.19

Also, I would ask to be made a maintainer on PyPI. My username there is cjmarkie.

cc @bucknerns @yarikoptic @bashtage @warner 