### PR TITLE
FIX: Improved handling of refname edge cases

### DIFF
--- a/src/git/from_keywords.py
+++ b/src/git/from_keywords.py
@@ -36,8 +36,8 @@ def git_get_keywords(versionfile_abs):
 @register_vcs_handler("git", "keywords")
 def git_versions_from_keywords(keywords, tag_prefix, verbose):
     """Get version information from git keywords."""
-    if not keywords:
-        raise NotThisMethod("no keywords at all, weird")
+    if "refnames" not in keywords:
+        raise NotThisMethod("Short version file found")
     date = keywords.get("date")
     if date is not None:
         # Use only the last line.  Previous lines may contain GPG signature

--- a/src/git/from_keywords.py
+++ b/src/git/from_keywords.py
@@ -78,6 +78,11 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
         # sorting will prefer e.g. "2.0" over "2.0rc1"
         if ref.startswith(tag_prefix):
             r = ref[len(tag_prefix):]
+            # Filter out refs that exactly match prefix or that don't start
+            # with a number once the prefix is stripped (mostly a concern
+            # when prefix is '')
+            if not re.match(r'\d', r):
+                continue
             if verbose:
                 print("picking %s" % r)
             return {"version": r,


### PR DESCRIPTION
This PR covers two edge cases.

The first is a case where the `keywords` passed to `git_versions_from_keywords()` is non-empty but `refnames` is missing. IIRC this could occur in `git archive`s for hashes that had no branches or tags associated. This breaks L54:

https://github.com/python-versioneer/python-versioneer/blob/8071eaa56816837ac670d18bdc73d7de6cb60ea6/src/git/from_keywords.py#L54

Instead we reduce the check to `'refnames' in keywords`, which covers the actually erroring case, and provide a better error message.

The second is a case where you might have a tag `test_tag`. If you have a tag prefix `'v'`, this will get filtered out. If your tag prefix is `''`, then all weird tags get pulled in. So I've added a filter that requires the first character of the tag (post-prefix) to be a digit.