### PR TITLE
Use _build_ext from cmds

### DIFF
--- a/src/cmdclass.py
+++ b/src/cmdclass.py
@@ -92,7 +92,9 @@ def get_cmdclass(cmdclass=None):
                 write_to_version_file(target_versionfile, versions)
     cmds["build_py"] = cmd_build_py
 
-    if "setuptools" in sys.modules:
+    if 'build_ext' in cmds:
+        _build_ext = cmds['build_ext']
+    elif "setuptools" in sys.modules:
         from setuptools.command.build_ext import build_ext as _build_ext
     else:
         from distutils.command.build_ext import build_ext as _build_ext


### PR DESCRIPTION
I had to add these lines in `myproject/versioneer.py` to be able to use a custom `build_ext` that is required in a project of mine using cython. I hope that I applied the change at the right place und the `python-versioneer`.