### PR TITLE
FIX: Respect versionfile_source in __init__.py snippet

### DIFF
--- a/src/setupfunc.py
+++ b/src/setupfunc.py
@@ -44,9 +44,8 @@ SAMPLE_CONFIG = """
 """
 
 INIT_PY_SNIPPET = """
-from ._version import get_versions
-__version__ = get_versions()['version']
-del get_versions
+from . import {0}
+__version__ = {0}.get_versions()['version']
 """
 
 
@@ -83,10 +82,12 @@ def do_setup():
                 old = f.read()
         except EnvironmentError:
             old = ""
-        if INIT_PY_SNIPPET not in old:
+        module = os.path.splitext(os.path.basename(cfg.versionfile_source))[0]
+        snippet = INIT_PY_SNIPPET.format(module)
+        if snippet not in old:
             print(" appending to %s" % ipy)
             with open(ipy, "a") as f:
-                f.write(INIT_PY_SNIPPET)
+                f.write(snippet)
         else:
             print(" %s unmodified" % ipy)
     else:

--- a/test/git/test_git.py
+++ b/test/git/test_git.py
@@ -419,9 +419,8 @@ class Repo(common.Common, unittest.TestCase):
         if not script_only:
             with open(self.project_file("src/demo/__init__.py")) as fobj:
                 i = fobj.read().splitlines()
-            self.assertEqual(i[-3], "from ._version import get_versions")
-            self.assertEqual(i[-2], "__version__ = get_versions()['version']")
-            self.assertEqual(i[-1], "del get_versions")
+            self.assertEqual(i[-2], "from . import _version")
+            self.assertEqual(i[-1], "__version__ = _version.get_versions()['version']")
         self.git("commit", "-m", "add _version stuff")
 
         # "versioneer.py setup" should be idempotent


### PR DESCRIPTION
Fixes #123, fixes #218.

Now uses the correct module name from versionfile_source in the \_\_init\_\_.py snippet.

Since I was changing it anyway I also included the fix mentioned in #218. The snippet no longer deletes any object called `get_versions` in the root module.