### PR TITLE
fix possible typo in build_ext

### DIFF
--- a/src/cmdclass.py
+++ b/src/cmdclass.py
@@ -114,7 +114,7 @@ def get_cmdclass(cmdclass=None):
             # now locate _version.py in the new build/ directory and replace
             # it with an updated value
             target_versionfile = os.path.join(self.build_lib,
-                                              cfg.versionfile_source)
+                                              cfg.versionfile_build)
             print("UPDATING %s" % target_versionfile)
             write_to_version_file(target_versionfile, versions)
     cmds["build_ext"] = cmd_build_ext


### PR DESCRIPTION
I don't know if it was intentional or not, but it was breaking `pip wheel` in my cython project which has `src/myproject` style project layout.
![image](https://user-images.githubusercontent.com/17181457/102972926-e4375180-4521-11eb-9671-bec0d81d433e.png)




