### PR TITLE
FIX: Escape asterisk in ``git describe`` call on Windows

### DIFF
--- a/src/git/from_vcs.py
+++ b/src/git/from_vcs.py
@@ -22,8 +22,10 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, runner=run_command):
     version string, meaning we're inside a checked out source tree.
     """
     GITS = ["git"]
+    TAG_PREFIX_REGEX = "*"
     if sys.platform == "win32":
         GITS = ["git.cmd", "git.exe"]
+        TAG_PREFIX_REGEX = "\*"
 
     _, rc = runner(GITS, ["rev-parse", "--git-dir"], cwd=root,
                    hide_stderr=True)
@@ -36,7 +38,8 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, runner=run_command):
     # if there isn't one, this yields HEX[-dirty] (no NUM)
     describe_out, rc = runner(GITS, ["describe", "--tags", "--dirty",
                                      "--always", "--long",
-                                     "--match", "%s*" % tag_prefix],
+                                     "--match",
+                                     "%s%s" % (tag_prefix, TAG_PREFIX_REGEX)],
                               cwd=root)
     # --long was added in git-1.5.5
     if describe_out is None:

--- a/src/git/from_vcs.py
+++ b/src/git/from_vcs.py
@@ -25,7 +25,7 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, runner=run_command):
     TAG_PREFIX_REGEX = "*"
     if sys.platform == "win32":
         GITS = ["git.cmd", "git.exe"]
-        TAG_PREFIX_REGEX = "\*"
+        TAG_PREFIX_REGEX = "\*" # noqa: W605
 
     _, rc = runner(GITS, ["rev-parse", "--git-dir"], cwd=root,
                    hide_stderr=True)

--- a/src/git/from_vcs.py
+++ b/src/git/from_vcs.py
@@ -25,7 +25,7 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, runner=run_command):
     TAG_PREFIX_REGEX = "*"
     if sys.platform == "win32":
         GITS = ["git.cmd", "git.exe"]
-        TAG_PREFIX_REGEX = "\*" # noqa: W605
+        TAG_PREFIX_REGEX = r"\*"
 
     _, rc = runner(GITS, ["rev-parse", "--git-dir"], cwd=root,
                    hide_stderr=True)


### PR DESCRIPTION
I have created a fix for #122.

This fix makes use of an existing check for `win32` to modifies the argument to `--match` accordingly so that the `*` is escaped for Windows users.