### PR TITLE
MAINT: EnvironmentError is an alias of OSError

### DIFF
--- a/src/from_file.py
+++ b/src/from_file.py
@@ -25,7 +25,7 @@ def versions_from_file(filename):
     try:
         with open(filename) as f:
             contents = f.read()
-    except EnvironmentError:
+    except OSError:
         raise NotThisMethod("unable to read _version.py")
     mo = re.search(r"version_json = '''\n(.*)'''  # END VERSION_JSON",
                    contents, re.M | re.S)

--- a/src/git/from_keywords.py
+++ b/src/git/from_keywords.py
@@ -27,7 +27,7 @@ def git_get_keywords(versionfile_abs):
                     mo = re.search(r'=\s*"(.*)"', line)
                     if mo:
                         keywords["date"] = mo.group(1)
-    except EnvironmentError:
+    except OSError:
         pass
     return keywords
 

--- a/src/git/install.py
+++ b/src/git/install.py
@@ -29,7 +29,7 @@ def do_vcs_install(manifest_in, versionfile_source, ipy):
                     if "export-subst" in line.strip().split()[1:]:
                         present = True
                         break
-    except EnvironmentError:
+    except OSError:
         pass
     if not present:
         with open(".gitattributes", "a+") as fobj:

--- a/src/header.py
+++ b/src/header.py
@@ -60,7 +60,7 @@ def get_root():
 
 def get_config_from_root(root):
     """Read the project setup.cfg file to determine Versioneer config."""
-    # This might raise EnvironmentError (if setup.cfg is missing), or
+    # This might raise OSError (if setup.cfg is missing), or
     # configparser.NoSectionError (if it lacks a [versioneer] section), or
     # configparser.NoOptionError (if it lacks "VCS="). See the docstring at
     # the top of versioneer.py for instructions on writing your setup.cfg .

--- a/src/setupfunc.py
+++ b/src/setupfunc.py
@@ -60,9 +60,9 @@ def do_setup():
     root = get_root()
     try:
         cfg = get_config_from_root(root)
-    except (EnvironmentError, configparser.NoSectionError,
+    except (OSError, configparser.NoSectionError,
             configparser.NoOptionError) as e:
-        if isinstance(e, (EnvironmentError, configparser.NoSectionError)):
+        if isinstance(e, (OSError, configparser.NoSectionError)):
             print("Adding sample versioneer config to setup.cfg",
                   file=sys.stderr)
             with open(os.path.join(root, "setup.cfg"), "a") as f:
@@ -86,7 +86,7 @@ def do_setup():
         try:
             with open(ipy, "r") as f:
                 old = f.read()
-        except EnvironmentError:
+        except OSError:
             old = ""
         module = os.path.splitext(os.path.basename(cfg.versionfile_source))[0]
         snippet = INIT_PY_SNIPPET.format(module)
@@ -116,7 +116,7 @@ def do_setup():
                 if line.startswith("include "):
                     for include in line.split()[1:]:
                         simple_includes.add(include)
-    except EnvironmentError:
+    except OSError:
         pass
     # That doesn't cover everything MANIFEST.in can do
     # (http://docs.python.org/2/distutils/sourcedist.html#commands), so

--- a/src/subprocess_helper.py
+++ b/src/subprocess_helper.py
@@ -14,7 +14,7 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
                                        stderr=(subprocess.PIPE if hide_stderr
                                                else None))
             break
-        except EnvironmentError:
+        except OSError:
             e = sys.exc_info()[1]
             if e.errno == errno.ENOENT:
                 continue


### PR DESCRIPTION
A change from Python 3.3 is that several errors were merged to [OSError](https://docs.python.org/3.7/library/exceptions.html#OSError), including EnvironmentError

```python
>>> EnvironmentError is OSError  # True
```

so this PR simply replaces EnvironmentError with OSError.