### PR TITLE
FIX: mypy fails after install

### DIFF
--- a/src/git/long_header.py
+++ b/src/git/long_header.py
@@ -14,6 +14,7 @@ import os
 import re
 import subprocess
 import sys
+from typing import Callable, Dict
 
 
 def get_keywords():
@@ -51,8 +52,8 @@ class NotThisMethod(Exception):
     """Exception raised if a method is not valid for the current scenario."""
 
 
-LONG_VERSION_PY = {}
-HANDLERS = {}
+LONG_VERSION_PY: Dict[str, str] = {}
+HANDLERS: Dict[str, Dict[str, Callable]] = {}
 
 
 def register_vcs_handler(vcs, method):  # decorator

--- a/src/header.py
+++ b/src/header.py
@@ -13,6 +13,7 @@ import os
 import re
 import subprocess
 import sys
+from typing import Callable, Dict
 
 
 class VersioneerConfig:  # pylint: disable=too-few-public-methods # noqa
@@ -92,8 +93,8 @@ class NotThisMethod(Exception):
 
 
 # these dictionaries contain VCS-specific tools
-LONG_VERSION_PY = {}
-HANDLERS = {}
+LONG_VERSION_PY: Dict[str, str] = {}
+HANDLERS: Dict[str, Dict[str, Callable]] = {}
 
 
 def register_vcs_handler(vcs, method):  # decorator


### PR DESCRIPTION
Fix for https://github.com/python-versioneer/python-versioneer/issues/268

Simply add type hints to `LONG_VERSION_PY` (use typing classes to support python<3.9)
