### PR TITLE
TEST: Pip 21.3 seems to fix subproject installations

### DIFF
--- a/test/git/test_invocations.py
+++ b/test/git/test_invocations.py
@@ -449,7 +449,6 @@ class DistutilsRepo(_Invocations, unittest.TestCase):
         self.run_in_venv(venv, repodir, "pip", "install", ".")
         self.check_in_venv(venv)
 
-    @unittest.expectedFailure
     def test_pip_install_subproject(self):
         projectdir = self.make_distutils_repo_subproject()
         venv = self.make_venv("distutils-repo-pip-install-subproject")
@@ -462,7 +461,6 @@ class DistutilsRepo(_Invocations, unittest.TestCase):
         self.run_in_venv(venv, venv, "pip", "install", repodir)
         self.check_in_venv(venv)
 
-    @unittest.expectedFailure
     def test_pip_install_from_afar_subproject(self):
         projectdir = self.make_distutils_repo_subproject()
         venv = self.make_venv("distutils-repo-pip-install-from-afar-subproject")
@@ -559,7 +557,6 @@ class SetuptoolsRepo(_Invocations, unittest.TestCase):
                          "--no-index", "--find-links", linkdir)
         self.check_in_venv_withlib(venv)
 
-    @unittest.expectedFailure
     def test_pip_install_subproject(self):
         linkdir = self.make_linkdir()
         projectdir = self.make_setuptools_repo_subproject()
@@ -576,7 +573,6 @@ class SetuptoolsRepo(_Invocations, unittest.TestCase):
                          "--no-index", "--find-links", linkdir)
         self.check_in_venv_withlib(venv)
 
-    @unittest.expectedFailure
     def test_pip_install_from_afar_subproject(self):
         linkdir = self.make_linkdir()
         projectdir = self.make_setuptools_repo_subproject()


### PR DESCRIPTION
This reverts commit bc47ececb0e9e7e0d60622817d566286869ba882.