### PR TITLE
Format with black

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ VERSION = "0.22.dev0"
 def ver(s):
     return s.replace("@VERSIONEER-VERSION@", VERSION)
 
+
 def get(fn, add_ver=False, unquote=False, do_strip=False, do_readme=False):
     with open(fn) as f:
         text = f.read()
@@ -24,30 +25,39 @@ def get(fn, add_ver=False, unquote=False, do_strip=False, do_readme=False):
     if unquote:
         text = text.replace("%", "%%")
     if do_strip:
-        text = "".join(line for line in text.splitlines(keepends=True)
-                         if not line.endswith("# --STRIP DURING BUILD\n"))
+        text = "".join(
+            line
+            for line in text.splitlines(keepends=True)
+            if not line.endswith("# --STRIP DURING BUILD\n")
+        )
     if do_readme:
         text = text.replace("@README@", get("README.md"))
     return text
 
+
 def get_vcs_list():
     project_path = Path(__file__).absolute().parent / "src"
-    return [filename
-            for filename
-            in os.listdir(str(project_path))
-            if Path.is_dir(project_path / filename) and filename != "__pycache__"]
+    return [
+        filename
+        for filename in os.listdir(str(project_path))
+        if Path.is_dir(project_path / filename) and filename != "__pycache__"
+    ]
+
 
 def generate_long_version_py(VCS):
     s = io.StringIO()
     s.write(get(f"src/{VCS}/long_header.py", add_ver=True, do_strip=True))
-    for piece in ["src/subprocess_helper.py",
-                  "src/from_parentdir.py",
-                  f"src/{VCS}/from_keywords.py",
-                  f"src/{VCS}/from_vcs.py",
-                  "src/render.py",
-                  f"src/{VCS}/long_get_versions.py"]:
+    for piece in [
+        "src/subprocess_helper.py",
+        "src/from_parentdir.py",
+        f"src/{VCS}/from_keywords.py",
+        f"src/{VCS}/from_vcs.py",
+        "src/render.py",
+        f"src/{VCS}/long_get_versions.py",
+    ]:
         s.write(get(piece, unquote=True, do_strip=True))
     return s.getvalue()
+
 
 def generate_versioneer_py():
     s = io.StringIO()
@@ -79,42 +89,53 @@ class make_versioneer(Command):
     description = "create standalone versioneer.py"
     user_options = []
     boolean_options = []
+
     def initialize_options(self):
         pass
+
     def finalize_options(self):
         pass
+
     def run(self):
         with open("versioneer.py", "w") as f:
             f.write(generate_versioneer_py().decode("utf8"))
         return 0
 
+
 class make_long_version_py_git(Command):
     description = "create standalone _version.py (for git)"
     user_options = []
     boolean_options = []
+
     def initialize_options(self):
         pass
+
     def finalize_options(self):
         pass
+
     def run(self):
         assert os.path.exists("versioneer.py")
         long_version = generate_long_version_py("git")
         with open("git_version.py", "w") as f:
-            f.write(long_version %
-                    {"DOLLAR": "$",
-                     "STYLE": "pep440",
-                     "TAG_PREFIX": "tag-",
-                     "PARENTDIR_PREFIX": "parentdir_prefix",
-                     "VERSIONFILE_SOURCE": "versionfile_source",
-                     })
+            f.write(
+                long_version
+                % {
+                    "DOLLAR": "$",
+                    "STYLE": "pep440",
+                    "TAG_PREFIX": "tag-",
+                    "PARENTDIR_PREFIX": "parentdir_prefix",
+                    "VERSIONFILE_SOURCE": "versionfile_source",
+                }
+            )
         return 0
+
 
 class my_build_py(build_py):
     def run(self):
         v = generate_versioneer_py()
         v_b64 = base64.b64encode(v).decode("ascii")
-        lines = [v_b64[i:i+60] for i in range(0, len(v_b64), 60)]
-        v_b64 = "\n".join(lines)+"\n"
+        lines = [v_b64[i : i + 60] for i in range(0, len(v_b64), 60)]
+        v_b64 = "\n".join(lines) + "\n"
 
         with open("src/installer.py") as f:
             s = f.read()
@@ -126,7 +147,7 @@ class my_build_py(build_py):
                 f.write(s)
 
             self.py_modules = [os.path.splitext(os.path.basename(installer))[0]]
-            self.package_dir.update({'': os.path.dirname(installer)})
+            self.package_dir.update({"": os.path.dirname(installer)})
             rc = build_py.run(self)
         return rc
 
@@ -136,32 +157,35 @@ class my_build_py(build_py):
 # this so we get cross-platform wheels instead. More info at:
 # https://bitbucket.org/pypa/wheel/issue/116/packages-with-only-filesdata_files-get
 class Distribution(_Distribution):
-    def is_pure(self): return True
+    def is_pure(self):
+        return True
+
 
 setup(
-    name = "versioneer",
-    license = "public domain",
-    version = VERSION,
-    description = "Easy VCS-based management of project version strings",
-    author = "Brian Warner",
-    author_email = "warner-versioneer@lothar.com",
-    url = "https://github.com/python-versioneer/python-versioneer",
+    name="versioneer",
+    license="public domain",
+    version=VERSION,
+    description="Easy VCS-based management of project version strings",
+    author="Brian Warner",
+    author_email="warner-versioneer@lothar.com",
+    url="https://github.com/python-versioneer/python-versioneer",
     # "fake" is replaced with versioneer-installer in build_scripts. We need
     # a non-empty list to provoke "setup.py build" into making scripts,
     # otherwise it skips that step.
-    py_modules = ["fake"],
+    py_modules=["fake"],
     entry_points={
-        'console_scripts': [
-            'versioneer = versioneer:main',
+        "console_scripts": [
+            "versioneer = versioneer:main",
         ],
     },
     long_description=LONG,
     long_description_content_type="text/markdown",
     distclass=Distribution,
-    cmdclass = { "build_py": my_build_py,
-                 "make_versioneer": make_versioneer,
-                 "make_long_version_py_git": make_long_version_py_git,
-                 },
+    cmdclass={
+        "build_py": my_build_py,
+        "make_versioneer": make_versioneer,
+        "make_long_version_py_git": make_long_version_py_git,
+    },
     python_requires=">=3.6",
     classifiers=[
         "Programming Language :: Python",
@@ -170,5 +194,5 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
-        ],
-    )
+    ],
+)

--- a/src/cmdclass.py
+++ b/src/cmdclass.py
@@ -1,10 +1,26 @@
-import os, sys # --STRIP DURING BUILD
-LONG_VERSION_PY = {} # --STRIP DURING BUILD
-def get_version(): pass # --STRIP DURING BUILD
-def get_versions(): pass # --STRIP DURING BUILD
-def get_root(): pass # --STRIP DURING BUILD
-def get_config_from_root(): pass # --STRIP DURING BUILD
-def write_to_version_file(): pass # --STRIP DURING BUILD
+import os, sys  # --STRIP DURING BUILD
+
+LONG_VERSION_PY = {}  # --STRIP DURING BUILD
+
+
+def get_version():
+    pass  # --STRIP DURING BUILD
+
+
+def get_versions():
+    pass  # --STRIP DURING BUILD
+
+
+def get_root():
+    pass  # --STRIP DURING BUILD
+
+
+def get_config_from_root():
+    pass  # --STRIP DURING BUILD
+
+
+def write_to_version_file():
+    pass  # --STRIP DURING BUILD
 
 
 def get_cmdclass(cmdclass=None):
@@ -52,6 +68,7 @@ def get_cmdclass(cmdclass=None):
             print(" date: %s" % vers.get("date"))
             if vers["error"]:
                 print(" error: %s" % vers["error"])
+
     cmds["version"] = cmd_version
 
     # we override "build_py" in both distutils and setuptools
@@ -70,8 +87,8 @@ def get_cmdclass(cmdclass=None):
     #  setup.py egg_info -> ?
 
     # we override different "build_py" commands for both environments
-    if 'build_py' in cmds:
-        _build_py = cmds['build_py']
+    if "build_py" in cmds:
+        _build_py = cmds["build_py"]
     elif "setuptools" in sys.modules:
         from setuptools.command.build_py import build_py as _build_py
     else:
@@ -86,14 +103,14 @@ def get_cmdclass(cmdclass=None):
             # now locate _version.py in the new build/ directory and replace
             # it with an updated value
             if cfg.versionfile_build:
-                target_versionfile = os.path.join(self.build_lib,
-                                                  cfg.versionfile_build)
+                target_versionfile = os.path.join(self.build_lib, cfg.versionfile_build)
                 print("UPDATING %s" % target_versionfile)
                 write_to_version_file(target_versionfile, versions)
+
     cmds["build_py"] = cmd_build_py
 
-    if 'build_ext' in cmds:
-        _build_ext = cmds['build_ext']
+    if "build_ext" in cmds:
+        _build_ext = cmds["build_ext"]
     elif "setuptools" in sys.modules:
         from setuptools.command.build_ext import build_ext as _build_ext
     else:
@@ -113,14 +130,15 @@ def get_cmdclass(cmdclass=None):
                 return
             # now locate _version.py in the new build/ directory and replace
             # it with an updated value
-            target_versionfile = os.path.join(self.build_lib,
-                                              cfg.versionfile_build)
+            target_versionfile = os.path.join(self.build_lib, cfg.versionfile_build)
             print("UPDATING %s" % target_versionfile)
             write_to_version_file(target_versionfile, versions)
+
     cmds["build_ext"] = cmd_build_ext
 
     if "cx_Freeze" in sys.modules:  # cx_freeze enabled?
         from cx_Freeze.dist import build_exe as _build_exe
+
         # nczeczulin reports that py2exe won't like the pep440-style string
         # as FILEVERSION, but it can be used for PRODUCTVERSION, e.g.
         # setup(console=[{
@@ -141,17 +159,21 @@ def get_cmdclass(cmdclass=None):
                 os.unlink(target_versionfile)
                 with open(cfg.versionfile_source, "w") as f:
                     LONG = LONG_VERSION_PY[cfg.VCS]
-                    f.write(LONG %
-                            {"DOLLAR": "$",
-                             "STYLE": cfg.style,
-                             "TAG_PREFIX": cfg.tag_prefix,
-                             "PARENTDIR_PREFIX": cfg.parentdir_prefix,
-                             "VERSIONFILE_SOURCE": cfg.versionfile_source,
-                             })
+                    f.write(
+                        LONG
+                        % {
+                            "DOLLAR": "$",
+                            "STYLE": cfg.style,
+                            "TAG_PREFIX": cfg.tag_prefix,
+                            "PARENTDIR_PREFIX": cfg.parentdir_prefix,
+                            "VERSIONFILE_SOURCE": cfg.versionfile_source,
+                        }
+                    )
+
         cmds["build_exe"] = cmd_build_exe
         del cmds["build_py"]
 
-    if 'py2exe' in sys.modules:  # py2exe enabled?
+    if "py2exe" in sys.modules:  # py2exe enabled?
         from py2exe.distutils_buildexe import py2exe as _py2exe
 
         class cmd_py2exe(_py2exe):
@@ -167,18 +189,22 @@ def get_cmdclass(cmdclass=None):
                 os.unlink(target_versionfile)
                 with open(cfg.versionfile_source, "w") as f:
                     LONG = LONG_VERSION_PY[cfg.VCS]
-                    f.write(LONG %
-                            {"DOLLAR": "$",
-                             "STYLE": cfg.style,
-                             "TAG_PREFIX": cfg.tag_prefix,
-                             "PARENTDIR_PREFIX": cfg.parentdir_prefix,
-                             "VERSIONFILE_SOURCE": cfg.versionfile_source,
-                             })
+                    f.write(
+                        LONG
+                        % {
+                            "DOLLAR": "$",
+                            "STYLE": cfg.style,
+                            "TAG_PREFIX": cfg.tag_prefix,
+                            "PARENTDIR_PREFIX": cfg.parentdir_prefix,
+                            "VERSIONFILE_SOURCE": cfg.versionfile_source,
+                        }
+                    )
+
         cmds["py2exe"] = cmd_py2exe
 
     # we override different "sdist" commands for both environments
-    if 'sdist' in cmds:
-        _sdist = cmds['sdist']
+    if "sdist" in cmds:
+        _sdist = cmds["sdist"]
     elif "setuptools" in sys.modules:
         from setuptools.command.sdist import sdist as _sdist
     else:
@@ -202,8 +228,10 @@ def get_cmdclass(cmdclass=None):
             # updated value
             target_versionfile = os.path.join(base_dir, cfg.versionfile_source)
             print("UPDATING %s" % target_versionfile)
-            write_to_version_file(target_versionfile,
-                                  self._versioneer_generated_versions)
+            write_to_version_file(
+                target_versionfile, self._versioneer_generated_versions
+            )
+
     cmds["sdist"] = cmd_sdist
 
     return cmds

--- a/src/from_file.py
+++ b/src/from_file.py
@@ -15,10 +15,14 @@ def get_versions():
     return json.loads(version_json)
 """
 
-import os # --STRIP DURING BUILD
-import json # --STRIP DURING BUILD
-import re # --STRIP DURING BUILD
-class NotThisMethod(Exception): pass  # --STRIP DURING BUILD
+import os  # --STRIP DURING BUILD
+import json  # --STRIP DURING BUILD
+import re  # --STRIP DURING BUILD
+
+
+class NotThisMethod(Exception):
+    pass  # --STRIP DURING BUILD
+
 
 def versions_from_file(filename):
     """Try to determine the version from _version.py if present."""
@@ -27,11 +31,13 @@ def versions_from_file(filename):
             contents = f.read()
     except OSError:
         raise NotThisMethod("unable to read _version.py")
-    mo = re.search(r"version_json = '''\n(.*)'''  # END VERSION_JSON",
-                   contents, re.M | re.S)
+    mo = re.search(
+        r"version_json = '''\n(.*)'''  # END VERSION_JSON", contents, re.M | re.S
+    )
     if not mo:
-        mo = re.search(r"version_json = '''\r\n(.*)'''  # END VERSION_JSON",
-                       contents, re.M | re.S)
+        mo = re.search(
+            r"version_json = '''\r\n(.*)'''  # END VERSION_JSON", contents, re.M | re.S
+        )
     if not mo:
         raise NotThisMethod("no version_json in _version.py")
     return json.loads(mo.group(1))
@@ -40,10 +46,8 @@ def versions_from_file(filename):
 def write_to_version_file(filename, versions):
     """Write the given version number to the given _version.py file."""
     os.unlink(filename)
-    contents = json.dumps(versions, sort_keys=True,
-                          indent=1, separators=(",", ": "))
+    contents = json.dumps(versions, sort_keys=True, indent=1, separators=(",", ": "))
     with open(filename, "w") as f:
         f.write(SHORT_VERSION_PY % contents)
 
     print("set %s to '%s'" % (filename, versions["version"]))
-

--- a/src/from_parentdir.py
+++ b/src/from_parentdir.py
@@ -1,5 +1,10 @@
-import os # --STRIP DURING BUILD
-class NotThisMethod(Exception): pass  # --STRIP DURING BUILD
+import os  # --STRIP DURING BUILD
+
+
+class NotThisMethod(Exception):
+    pass  # --STRIP DURING BUILD
+
+
 def versions_from_parentdir(parentdir_prefix, root, verbose):
     """Try to determine the version from the parent directory name.
 
@@ -12,15 +17,19 @@ def versions_from_parentdir(parentdir_prefix, root, verbose):
     for _ in range(3):
         dirname = os.path.basename(root)
         if dirname.startswith(parentdir_prefix):
-            return {"version": dirname[len(parentdir_prefix):],
-                    "full-revisionid": None,
-                    "dirty": False, "error": None, "date": None}
+            return {
+                "version": dirname[len(parentdir_prefix) :],
+                "full-revisionid": None,
+                "dirty": False,
+                "error": None,
+                "date": None,
+            }
         rootdirs.append(root)
         root = os.path.dirname(root)  # up a level
 
     if verbose:
-        print("Tried directories %s but none started with prefix %s" %
-              (str(rootdirs), parentdir_prefix))
+        print(
+            "Tried directories %s but none started with prefix %s"
+            % (str(rootdirs), parentdir_prefix)
+        )
     raise NotThisMethod("rootdir doesn't start with parentdir_prefix")
-
-

--- a/src/get_versions.py
+++ b/src/get_versions.py
@@ -1,11 +1,32 @@
-import os, sys # --STRIP DURING BUILD
-def get_root(): pass # --STRIP DURING BUILD
-def get_config_from_root(): pass # --STRIP DURING BUILD
-def versions_from_file(): pass # --STRIP DURING BUILD
-def versions_from_parentdir(): pass # --STRIP DURING BUILD
-def render(): pass # --STRIP DURING BUILD
-HANDLERS = {} # --STRIP DURING BUILD
-class NotThisMethod(Exception): pass  # --STRIP DURING BUILD
+import os, sys  # --STRIP DURING BUILD
+
+
+def get_root():
+    pass  # --STRIP DURING BUILD
+
+
+def get_config_from_root():
+    pass  # --STRIP DURING BUILD
+
+
+def versions_from_file():
+    pass  # --STRIP DURING BUILD
+
+
+def versions_from_parentdir():
+    pass  # --STRIP DURING BUILD
+
+
+def render():
+    pass  # --STRIP DURING BUILD
+
+
+HANDLERS = {}  # --STRIP DURING BUILD
+
+
+class NotThisMethod(Exception):
+    pass  # --STRIP DURING BUILD
+
 
 class VersioneerBadRootError(Exception):
     """The project root directory is unknown or missing key files."""
@@ -27,8 +48,9 @@ def get_versions(verbose=False):
     handlers = HANDLERS.get(cfg.VCS)
     assert handlers, "unrecognized VCS '%s'" % cfg.VCS
     verbose = verbose or cfg.verbose
-    assert cfg.versionfile_source is not None, \
-        "please set versioneer.versionfile_source"
+    assert (
+        cfg.versionfile_source is not None
+    ), "please set versioneer.versionfile_source"
     assert cfg.tag_prefix is not None, "please set versioneer.tag_prefix"
 
     versionfile_abs = os.path.join(root, cfg.versionfile_source)
@@ -82,9 +104,13 @@ def get_versions(verbose=False):
     if verbose:
         print("unable to compute version")
 
-    return {"version": "0+unknown", "full-revisionid": None,
-            "dirty": None, "error": "unable to compute version",
-            "date": None}
+    return {
+        "version": "0+unknown",
+        "full-revisionid": None,
+        "dirty": None,
+        "error": "unable to compute version",
+        "date": None,
+    }
 
 
 def get_version():

--- a/src/git/from_keywords.py
+++ b/src/git/from_keywords.py
@@ -1,9 +1,17 @@
-import re # --STRIP DURING BUILD
-def register_vcs_handler(*args): # --STRIP DURING BUILD
-    def nil(f): # --STRIP DURING BUILD
-        return f # --STRIP DURING BUILD
-    return nil # --STRIP DURING BUILD
-class NotThisMethod(Exception): pass  # --STRIP DURING BUILD
+import re  # --STRIP DURING BUILD
+
+
+def register_vcs_handler(*args):  # --STRIP DURING BUILD
+    def nil(f):  # --STRIP DURING BUILD
+        return f  # --STRIP DURING BUILD
+
+    return nil  # --STRIP DURING BUILD
+
+
+class NotThisMethod(Exception):
+    pass  # --STRIP DURING BUILD
+
+
 @register_vcs_handler("git", "get_keywords")
 def git_get_keywords(versionfile_abs):
     """Extract version information from the given file."""
@@ -59,7 +67,7 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
     # starting in git-1.8.3, tags are listed as "tag: foo-1.0" instead of
     # just "foo-1.0". If we see a "tag: " prefix, prefer those.
     TAG = "tag: "
-    tags = {r[len(TAG):] for r in refs if r.startswith(TAG)}
+    tags = {r[len(TAG) :] for r in refs if r.startswith(TAG)}
     if not tags:
         # Either we're using git < 1.8.3, or there really are no tags. We use
         # a heuristic: assume all version tags have a digit. The old git %d
@@ -68,7 +76,7 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
         # between branches and tags. By ignoring refnames without digits, we
         # filter out many common branch names like "release" and
         # "stabilization", as well as "HEAD" and "master".
-        tags = {r for r in refs if re.search(r'\d', r)}
+        tags = {r for r in refs if re.search(r"\d", r)}
         if verbose:
             print("discarding '%s', no digits" % ",".join(refs - tags))
     if verbose:
@@ -76,23 +84,28 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
     for ref in sorted(tags):
         # sorting will prefer e.g. "2.0" over "2.0rc1"
         if ref.startswith(tag_prefix):
-            r = ref[len(tag_prefix):]
+            r = ref[len(tag_prefix) :]
             # Filter out refs that exactly match prefix or that don't start
             # with a number once the prefix is stripped (mostly a concern
             # when prefix is '')
-            if not re.match(r'\d', r):
+            if not re.match(r"\d", r):
                 continue
             if verbose:
                 print("picking %s" % r)
-            return {"version": r,
-                    "full-revisionid": keywords["full"].strip(),
-                    "dirty": False, "error": None,
-                    "date": date}
+            return {
+                "version": r,
+                "full-revisionid": keywords["full"].strip(),
+                "dirty": False,
+                "error": None,
+                "date": date,
+            }
     # no suitable tags, so version is "0+unknown", but full hex is still there
     if verbose:
         print("no suitable tags, using unknown + full revision id")
-    return {"version": "0+unknown",
-            "full-revisionid": keywords["full"].strip(),
-            "dirty": False, "error": "no suitable tags", "date": None}
-
-
+    return {
+        "version": "0+unknown",
+        "full-revisionid": keywords["full"].strip(),
+        "dirty": False,
+        "error": "no suitable tags",
+        "date": None,
+    }

--- a/src/git/from_vcs.py
+++ b/src/git/from_vcs.py
@@ -1,18 +1,27 @@
 import sys  # --STRIP DURING BUILD
 import re  # --STRIP DURING BUILD
-  # --STRIP DURING BUILD
-  # --STRIP DURING BUILD
+
+# --STRIP DURING BUILD
+# --STRIP DURING BUILD
 def register_vcs_handler(*args):  # --STRIP DURING BUILD
     def nil(f):  # --STRIP DURING BUILD
         return f  # --STRIP DURING BUILD
+
     return nil  # --STRIP DURING BUILD
-  # --STRIP DURING BUILD
-  # --STRIP DURING BUILD
-def run_command(): pass  # --STRIP DURING BUILD
-  # --STRIP DURING BUILD
-  # --STRIP DURING BUILD
+
+
+# --STRIP DURING BUILD
+# --STRIP DURING BUILD
+def run_command():
+    pass  # --STRIP DURING BUILD
+
+
+# --STRIP DURING BUILD
+# --STRIP DURING BUILD
 class NotThisMethod(Exception):  # --STRIP DURING BUILD
     pass  # --STRIP DURING BUILD
+
+
 @register_vcs_handler("git", "pieces_from_vcs")
 def git_pieces_from_vcs(tag_prefix, root, verbose, runner=run_command):
     """Get version from 'git describe' in the root of the source tree.
@@ -27,8 +36,7 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, runner=run_command):
         GITS = ["git.cmd", "git.exe"]
         TAG_PREFIX_REGEX = r"\*"
 
-    _, rc = runner(GITS, ["rev-parse", "--git-dir"], cwd=root,
-                   hide_stderr=True)
+    _, rc = runner(GITS, ["rev-parse", "--git-dir"], cwd=root, hide_stderr=True)
     if rc != 0:
         if verbose:
             print("Directory %s not under git control" % root)
@@ -36,11 +44,19 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, runner=run_command):
 
     # if there is a tag matching tag_prefix, this yields TAG-NUM-gHEX[-dirty]
     # if there isn't one, this yields HEX[-dirty] (no NUM)
-    describe_out, rc = runner(GITS, ["describe", "--tags", "--dirty",
-                                     "--always", "--long",
-                                     "--match",
-                                     "%s%s" % (tag_prefix, TAG_PREFIX_REGEX)],
-                              cwd=root)
+    describe_out, rc = runner(
+        GITS,
+        [
+            "describe",
+            "--tags",
+            "--dirty",
+            "--always",
+            "--long",
+            "--match",
+            "%s%s" % (tag_prefix, TAG_PREFIX_REGEX),
+        ],
+        cwd=root,
+    )
     # --long was added in git-1.5.5
     if describe_out is None:
         raise NotThisMethod("'git describe' failed")
@@ -55,8 +71,7 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, runner=run_command):
     pieces["short"] = full_out[:7]  # maybe improved later
     pieces["error"] = None
 
-    branch_name, rc = runner(GITS, ["rev-parse", "--abbrev-ref", "HEAD"],
-                             cwd=root)
+    branch_name, rc = runner(GITS, ["rev-parse", "--abbrev-ref", "HEAD"], cwd=root)
     # --abbrev-ref was added in git-1.6.3
     if rc != 0 or branch_name is None:
         raise NotThisMethod("'git rev-parse --abbrev-ref' returned error")
@@ -96,17 +111,16 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, runner=run_command):
     dirty = git_describe.endswith("-dirty")
     pieces["dirty"] = dirty
     if dirty:
-        git_describe = git_describe[:git_describe.rindex("-dirty")]
+        git_describe = git_describe[: git_describe.rindex("-dirty")]
 
     # now we have TAG-NUM-gHEX or HEX
 
     if "-" in git_describe:
         # TAG-NUM-gHEX
-        mo = re.search(r'^(.+)-(\d+)-g([0-9a-f]+)$', git_describe)
+        mo = re.search(r"^(.+)-(\d+)-g([0-9a-f]+)$", git_describe)
         if not mo:
             # unparsable. Maybe git-describe is misbehaving?
-            pieces["error"] = ("unable to parse git-describe output: '%s'"
-                               % describe_out)
+            pieces["error"] = "unable to parse git-describe output: '%s'" % describe_out
             return pieces
 
         # tag
@@ -115,10 +129,12 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, runner=run_command):
             if verbose:
                 fmt = "tag '%s' doesn't start with prefix '%s'"
                 print(fmt % (full_tag, tag_prefix))
-            pieces["error"] = ("tag '%s' doesn't start with prefix '%s'"
-                               % (full_tag, tag_prefix))
+            pieces["error"] = "tag '%s' doesn't start with prefix '%s'" % (
+                full_tag,
+                tag_prefix,
+            )
             return pieces
-        pieces["closest-tag"] = full_tag[len(tag_prefix):]
+        pieces["closest-tag"] = full_tag[len(tag_prefix) :]
 
         # distance: number of commits since tag
         pieces["distance"] = int(mo.group(2))
@@ -140,4 +156,3 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, runner=run_command):
     pieces["date"] = date.strip().replace(" ", "T", 1).replace(" ", "", 1)
 
     return pieces
-

--- a/src/git/install.py
+++ b/src/git/install.py
@@ -1,5 +1,9 @@
-import sys # --STRIP DURING BUILD
-def run_command(): pass # --STRIP DURING BUILD
+import sys  # --STRIP DURING BUILD
+
+
+def run_command():
+    pass  # --STRIP DURING BUILD
+
 
 def do_vcs_install(manifest_in, versionfile_source, ipy):
     """Git-specific installation logic for Versioneer.
@@ -36,5 +40,3 @@ def do_vcs_install(manifest_in, versionfile_source, ipy):
             fobj.write(f"{versionfile_source} export-subst\n")
         files.append(".gitattributes")
     run_command(GITS, ["add", "--"] + files)
-
-

--- a/src/git/long_get_versions.py
+++ b/src/git/long_get_versions.py
@@ -1,11 +1,33 @@
-import os # --STRIP DURING BUILD
-def get_config(): pass # --STRIP DURING BUILD
-def get_keywords(): pass # --STRIP DURING BUILD
-def git_versions_from_keywords(): pass # --STRIP DURING BUILD
-def git_pieces_from_vcs(): pass # --STRIP DURING BUILD
-def versions_from_parentdir(): pass # --STRIP DURING BUILD
-class NotThisMethod(Exception): pass  # --STRIP DURING BUILD
-def render(): pass # --STRIP DURING BUILD
+import os  # --STRIP DURING BUILD
+
+
+def get_config():
+    pass  # --STRIP DURING BUILD
+
+
+def get_keywords():
+    pass  # --STRIP DURING BUILD
+
+
+def git_versions_from_keywords():
+    pass  # --STRIP DURING BUILD
+
+
+def git_pieces_from_vcs():
+    pass  # --STRIP DURING BUILD
+
+
+def versions_from_parentdir():
+    pass  # --STRIP DURING BUILD
+
+
+class NotThisMethod(Exception):
+    pass  # --STRIP DURING BUILD
+
+
+def render():
+    pass  # --STRIP DURING BUILD
+
 
 def get_versions():
     """Get version information or return default if unable to do so."""
@@ -18,8 +40,7 @@ def get_versions():
     verbose = cfg.verbose
 
     try:
-        return git_versions_from_keywords(get_keywords(), cfg.tag_prefix,
-                                          verbose)
+        return git_versions_from_keywords(get_keywords(), cfg.tag_prefix, verbose)
     except NotThisMethod:
         pass
 
@@ -28,13 +49,16 @@ def get_versions():
         # versionfile_source is the relative path from the top of the source
         # tree (where the .git directory might live) to this file. Invert
         # this to find the root from __file__.
-        for _ in cfg.versionfile_source.split('/'):
+        for _ in cfg.versionfile_source.split("/"):
             root = os.path.dirname(root)
     except NameError:
-        return {"version": "0+unknown", "full-revisionid": None,
-                "dirty": None,
-                "error": "unable to find root of source tree",
-                "date": None}
+        return {
+            "version": "0+unknown",
+            "full-revisionid": None,
+            "dirty": None,
+            "error": "unable to find root of source tree",
+            "date": None,
+        }
 
     try:
         pieces = git_pieces_from_vcs(cfg.tag_prefix, root, verbose)
@@ -48,6 +72,10 @@ def get_versions():
     except NotThisMethod:
         pass
 
-    return {"version": "0+unknown", "full-revisionid": None,
-            "dirty": None,
-            "error": "unable to compute version", "date": None}
+    return {
+        "version": "0+unknown",
+        "full-revisionid": None,
+        "dirty": None,
+        "error": "unable to compute version",
+        "date": None,
+    }

--- a/src/git/long_header.py
+++ b/src/git/long_header.py
@@ -58,12 +58,12 @@ HANDLERS: Dict[str, Dict[str, Callable]] = {}
 
 def register_vcs_handler(vcs, method):  # decorator
     """Create decorator to mark a method as the handler of a VCS."""
+
     def decorate(f):
         """Store f in HANDLERS[vcs][method]."""
         if vcs not in HANDLERS:
             HANDLERS[vcs] = {}
         HANDLERS[vcs][method] = f
         return f
+
     return decorate
-
-

--- a/src/header.py
+++ b/src/header.py
@@ -1,4 +1,3 @@
-
 # Version: @VERSIONEER-VERSION@
 
 """The Versioneer - like a rocketeer, but for versions.
@@ -40,11 +39,13 @@ def get_root():
         setup_py = os.path.join(root, "setup.py")
         versioneer_py = os.path.join(root, "versioneer.py")
     if not (os.path.exists(setup_py) or os.path.exists(versioneer_py)):
-        err = ("Versioneer was unable to run the project root directory. "
-               "Versioneer requires setup.py to be executed from "
-               "its immediate directory (like 'python setup.py COMMAND'), "
-               "or in a way that lets it use sys.argv[0] to find the root "
-               "(like 'python path/to/setup.py COMMAND').")
+        err = (
+            "Versioneer was unable to run the project root directory. "
+            "Versioneer requires setup.py to be executed from "
+            "its immediate directory (like 'python setup.py COMMAND'), "
+            "or in a way that lets it use sys.argv[0] to find the root "
+            "(like 'python path/to/setup.py COMMAND')."
+        )
         raise VersioneerBadRootError(err)
     try:
         # Certain runtime workflows (setup.py install/develop in a setuptools
@@ -57,8 +58,10 @@ def get_root():
         me_dir = os.path.normcase(os.path.splitext(my_path)[0])
         vsr_dir = os.path.normcase(os.path.splitext(versioneer_py)[0])
         if me_dir != vsr_dir:
-            print("Warning: build in %s is using versioneer.py from %s"
-                  % (os.path.dirname(my_path), versioneer_py))
+            print(
+                "Warning: build in %s is using versioneer.py from %s"
+                % (os.path.dirname(my_path), versioneer_py)
+            )
     except NameError:
         pass
     return root
@@ -103,10 +106,10 @@ HANDLERS: Dict[str, Dict[str, Callable]] = {}
 
 def register_vcs_handler(vcs, method):  # decorator
     """Create decorator to mark a method as the handler of a VCS."""
+
     def decorate(f):
         """Store f in HANDLERS[vcs][method]."""
         HANDLERS.setdefault(vcs, {})[method] = f
         return f
+
     return decorate
-
-

--- a/src/installer.py
+++ b/src/installer.py
@@ -22,11 +22,11 @@ def main():
         print("Usage: versioneer install")
         sys.exit(1)
 
-    v = base64.b64decode(VERSIONEER_b64.encode('ASCII'))
+    v = base64.b64decode(VERSIONEER_b64.encode("ASCII"))
     if os.path.exists("versioneer.py"):
         for line in open("versioneer.py").readlines()[:5]:
             if line.startswith("# Version: "):
-                oldver = line[len("# Version: "):].strip()
+                oldver = line[len("# Version: ") :].strip()
                 if oldver != newver:
                     print("replacing old versioneer.py (%s)" % oldver)
                 break
@@ -38,9 +38,11 @@ def main():
     print("Now running 'versioneer.py setup' to install the generated files..")
     if " " in sys.executable:
         import subprocess  # Do not import unless absolutely necessary to avoid compatibility issues
+
         subprocess.call([sys.executable, "versioneer.py", "setup"])
     else:
         os.execl(sys.executable, sys.executable, "versioneer.py", "setup")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/src/render.py
+++ b/src/render.py
@@ -1,4 +1,3 @@
-
 def plus_or_dot(pieces):
     """Return a + if we don't already have one, else return a ."""
     if "+" in pieces.get("closest-tag", ""):
@@ -24,8 +23,7 @@ def render_pep440(pieces):
                 rendered += ".dirty"
     else:
         # exception #1
-        rendered = "0+untagged.%d.g%s" % (pieces["distance"],
-                                          pieces["short"])
+        rendered = "0+untagged.%d.g%s" % (pieces["distance"], pieces["short"])
         if pieces["dirty"]:
             rendered += ".dirty"
     return rendered
@@ -54,8 +52,7 @@ def render_pep440_branch(pieces):
         rendered = "0"
         if pieces["branch"] != "master":
             rendered += ".dev0"
-        rendered += "+untagged.%d.g%s" % (pieces["distance"],
-                                          pieces["short"])
+        rendered += "+untagged.%d.g%s" % (pieces["distance"], pieces["short"])
         if pieces["dirty"]:
             rendered += ".dirty"
     return rendered
@@ -83,7 +80,7 @@ def render_pep440_pre(pieces):
             tag_version, post_version = pep440_split_post(pieces["closest-tag"])
             rendered = tag_version
             if post_version is not None:
-                rendered += ".post%d.dev%d" % (post_version+1, pieces["distance"])
+                rendered += ".post%d.dev%d" % (post_version + 1, pieces["distance"])
             else:
                 rendered += ".post0.dev%d" % (pieces["distance"])
         else:
@@ -216,11 +213,13 @@ def render_git_describe_long(pieces):
 def render(pieces, style):
     """Render the given version pieces into the requested style."""
     if pieces["error"]:
-        return {"version": "unknown",
-                "full-revisionid": pieces.get("long"),
-                "dirty": None,
-                "error": pieces["error"],
-                "date": None}
+        return {
+            "version": "unknown",
+            "full-revisionid": pieces.get("long"),
+            "dirty": None,
+            "error": pieces["error"],
+            "date": None,
+        }
 
     if not style or style == "default":
         style = "pep440"  # the default
@@ -244,7 +243,10 @@ def render(pieces, style):
     else:
         raise ValueError("unknown style '%s'" % style)
 
-    return {"version": rendered, "full-revisionid": pieces["long"],
-            "dirty": pieces["dirty"], "error": None,
-            "date": pieces.get("date")}
-
+    return {
+        "version": rendered,
+        "full-revisionid": pieces["long"],
+        "dirty": pieces["dirty"],
+        "error": None,
+        "date": pieces.get("date"),
+    }

--- a/src/setupfunc.py
+++ b/src/setupfunc.py
@@ -1,10 +1,22 @@
-
 import os, sys  # --STRIP DURING BUILD
-def get_root(): pass # --STRIP DURING BUILD
-def get_config_from_root(): pass # --STRIP DURING BUILD
-LONG_VERSION_PY = {} # --STRIP DURING BUILD
-def do_vcs_install(): pass # --STRIP DURING BUILD
-configparser = None # --STRIP DURING BUILD
+
+
+def get_root():
+    pass  # --STRIP DURING BUILD
+
+
+def get_config_from_root():
+    pass  # --STRIP DURING BUILD
+
+
+LONG_VERSION_PY = {}  # --STRIP DURING BUILD
+
+
+def do_vcs_install():
+    pass  # --STRIP DURING BUILD
+
+
+configparser = None  # --STRIP DURING BUILD
 
 CONFIG_ERROR = """
 setup.cfg is missing the necessary Versioneer configuration. You need
@@ -60,11 +72,9 @@ def do_setup():
     root = get_root()
     try:
         cfg = get_config_from_root(root)
-    except (OSError, configparser.NoSectionError,
-            configparser.NoOptionError) as e:
+    except (OSError, configparser.NoSectionError, configparser.NoOptionError) as e:
         if isinstance(e, (OSError, configparser.NoSectionError)):
-            print("Adding sample versioneer config to setup.cfg",
-                  file=sys.stderr)
+            print("Adding sample versioneer config to setup.cfg", file=sys.stderr)
             with open(os.path.join(root, "setup.cfg"), "a") as f:
                 f.write(SAMPLE_CONFIG)
         print(CONFIG_ERROR, file=sys.stderr)
@@ -73,15 +83,18 @@ def do_setup():
     print(" creating %s" % cfg.versionfile_source)
     with open(cfg.versionfile_source, "w") as f:
         LONG = LONG_VERSION_PY[cfg.VCS]
-        f.write(LONG % {"DOLLAR": "$",
-                        "STYLE": cfg.style,
-                        "TAG_PREFIX": cfg.tag_prefix,
-                        "PARENTDIR_PREFIX": cfg.parentdir_prefix,
-                        "VERSIONFILE_SOURCE": cfg.versionfile_source,
-                        })
+        f.write(
+            LONG
+            % {
+                "DOLLAR": "$",
+                "STYLE": cfg.style,
+                "TAG_PREFIX": cfg.tag_prefix,
+                "PARENTDIR_PREFIX": cfg.parentdir_prefix,
+                "VERSIONFILE_SOURCE": cfg.versionfile_source,
+            }
+        )
 
-    ipy = os.path.join(os.path.dirname(cfg.versionfile_source),
-                       "__init__.py")
+    ipy = os.path.join(os.path.dirname(cfg.versionfile_source), "__init__.py")
     if os.path.exists(ipy):
         try:
             with open(ipy, "r") as f:
@@ -129,8 +142,10 @@ def do_setup():
     else:
         print(" 'versioneer.py' already in MANIFEST.in")
     if cfg.versionfile_source not in simple_includes:
-        print(" appending versionfile_source ('%s') to MANIFEST.in" %
-              cfg.versionfile_source)
+        print(
+            " appending versionfile_source ('%s') to MANIFEST.in"
+            % cfg.versionfile_source
+        )
         with open(manifest_in, "a") as f:
             f.write("include %s\n" % cfg.versionfile_source)
     else:

--- a/src/subprocess_helper.py
+++ b/src/subprocess_helper.py
@@ -1,6 +1,7 @@
-import sys, subprocess, errno # --STRIP DURING BUILD
-def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
-                env=None):
+import sys, subprocess, errno  # --STRIP DURING BUILD
+
+
+def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False, env=None):
     """Call the given command(s)."""
     assert isinstance(commands, list)
     process = None
@@ -8,10 +9,13 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
         try:
             dispcmd = str([command] + args)
             # remember shell=False, so use git.cmd on windows, not just git
-            process = subprocess.Popen([command] + args, cwd=cwd, env=env,
-                                       stdout=subprocess.PIPE,
-                                       stderr=(subprocess.PIPE if hide_stderr
-                                               else None))
+            process = subprocess.Popen(
+                [command] + args,
+                cwd=cwd,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=(subprocess.PIPE if hide_stderr else None),
+            )
             break
         except OSError:
             e = sys.exc_info()[1]
@@ -32,5 +36,3 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
             print("stdout was %s" % stdout)
         return None, process.returncode
     return stdout, process.returncode
-
-

--- a/test/demoapp-script-only/setup.py
+++ b/test/demoapp-script-only/setup.py
@@ -1,9 +1,10 @@
-
 import os, tempfile
 from setuptools import setup
 from distutils.command.build_scripts import build_scripts
 import versioneer
+
 commands = versioneer.get_cmdclass().copy()
+
 
 class my_build_scripts(build_scripts):
     def run(self):
@@ -13,7 +14,7 @@ class my_build_scripts(build_scripts):
         with open(generated, "wb") as f:
             for line in open("src/rundemo-template", "rb"):
                 if line.strip().decode("ascii") == "versions = None":
-                    f.write(('versions = %r\n' % (versions,)).encode("ascii"))
+                    f.write(("versions = %r\n" % (versions,)).encode("ascii"))
                 else:
                     f.write(line)
         self.scripts = [generated]
@@ -21,19 +22,22 @@ class my_build_scripts(build_scripts):
         os.unlink(generated)
         os.rmdir(tempdir)
         return rc
+
+
 commands["build_scripts"] = my_build_scripts
 
-setup(name="demo",
-      version=versioneer.get_version(),
-      description="Demo",
-      url="url",
-      author="author",
-      author_email="email",
-      zip_safe=True,
-      scripts=["src/dummy"], # this will be replaced by my_build_scripts
-      # without py_modules= or packages=, distutils thinks this module is not
-      # "pure", and will put a platform indicator in the .whl name even
-      # though we call bdist_wheel with --universal.
-      py_modules=["fake"],
-      cmdclass=commands,
-      )
+setup(
+    name="demo",
+    version=versioneer.get_version(),
+    description="Demo",
+    url="url",
+    author="author",
+    author_email="email",
+    zip_safe=True,
+    scripts=["src/dummy"],  # this will be replaced by my_build_scripts
+    # without py_modules= or packages=, distutils thinks this module is not
+    # "pure", and will put a platform indicator in the .whl name even
+    # though we call bdist_wheel with --universal.
+    py_modules=["fake"],
+    cmdclass=commands,
+)

--- a/test/demoapp/setup.py
+++ b/test/demoapp/setup.py
@@ -1,17 +1,18 @@
-
 from setuptools import setup
 import versioneer
+
 commands = versioneer.get_cmdclass().copy()
 
-setup(name="demo",
-      version=versioneer.get_version(),
-      description="Demo",
-      url="url",
-      author="author",
-      author_email="email",
-      zip_safe=True,
-      packages=["demo"],
-      package_dir={"": "src"},
-      scripts=["bin/rundemo"],
-      cmdclass=commands,
-      )
+setup(
+    name="demo",
+    version=versioneer.get_version(),
+    description="Demo",
+    url="url",
+    author="author",
+    author_email="email",
+    zip_safe=True,
+    packages=["demo"],
+    package_dir={"": "src"},
+    scripts=["bin/rundemo"],
+    cmdclass=commands,
+)

--- a/test/demoapp2-distutils-subproject/subproject/setup.py
+++ b/test/demoapp2-distutils-subproject/subproject/setup.py
@@ -1,16 +1,17 @@
-
 from distutils.core import setup
 import versioneer
+
 commands = versioneer.get_cmdclass().copy()
 
-setup(name="demoapp2",
-      version=versioneer.get_version(),
-      description="Demo",
-      url="url",
-      author="author",
-      author_email="email",
-      packages=["demo"],
-      package_dir={"": "src"},
-      scripts=["bin/rundemo"],
-      cmdclass=commands,
-      )
+setup(
+    name="demoapp2",
+    version=versioneer.get_version(),
+    description="Demo",
+    url="url",
+    author="author",
+    author_email="email",
+    packages=["demo"],
+    package_dir={"": "src"},
+    scripts=["bin/rundemo"],
+    cmdclass=commands,
+)

--- a/test/demoapp2-distutils/setup.py
+++ b/test/demoapp2-distutils/setup.py
@@ -1,16 +1,17 @@
-
 from distutils.core import setup
 import versioneer
+
 commands = versioneer.get_cmdclass().copy()
 
-setup(name="demoapp2",
-      version=versioneer.get_version(),
-      description="Demo",
-      url="url",
-      author="author",
-      author_email="email",
-      packages=["demo"],
-      package_dir={"": "src"},
-      scripts=["bin/rundemo"],
-      cmdclass=commands,
-      )
+setup(
+    name="demoapp2",
+    version=versioneer.get_version(),
+    description="Demo",
+    url="url",
+    author="author",
+    author_email="email",
+    packages=["demo"],
+    package_dir={"": "src"},
+    scripts=["bin/rundemo"],
+    cmdclass=commands,
+)

--- a/test/demoapp2-setuptools-subproject/subproject/setup.py
+++ b/test/demoapp2-setuptools-subproject/subproject/setup.py
@@ -1,20 +1,21 @@
-
 from setuptools import setup
 import versioneer
+
 commands = versioneer.get_cmdclass().copy()
 
-setup(name="demoapp2",
-      version=versioneer.get_version(),
-      description="Demo",
-      url="url",
-      author="author",
-      author_email="email",
-      zip_safe=True,
-      packages=["demo"],
-      package_dir={"": "src"},
-      entry_points={
-          'console_scripts': [ 'rundemo = demo.main:run' ],
-          },
-      install_requires=["demolib==1.0"],
-      cmdclass=commands,
-      )
+setup(
+    name="demoapp2",
+    version=versioneer.get_version(),
+    description="Demo",
+    url="url",
+    author="author",
+    author_email="email",
+    zip_safe=True,
+    packages=["demo"],
+    package_dir={"": "src"},
+    entry_points={
+        "console_scripts": ["rundemo = demo.main:run"],
+    },
+    install_requires=["demolib==1.0"],
+    cmdclass=commands,
+)

--- a/test/demoapp2-setuptools-subproject/subproject/src/demo/main.py
+++ b/test/demoapp2-setuptools-subproject/subproject/src/demo/main.py
@@ -4,10 +4,11 @@ import demo
 from demo import _version
 from demolib import __version__ as libversion
 
+
 def run(*args, **kwargs):
     print("__version__:%s" % demo.__version__)
     print("_version:%s" % str(_version))
     versions = _version.get_versions()
     for k in sorted(versions.keys()):
-        print("%s:%s" % (k,versions[k]))
+        print("%s:%s" % (k, versions[k]))
     print("demolib:%s" % libversion)

--- a/test/demoapp2-setuptools/setup.py
+++ b/test/demoapp2-setuptools/setup.py
@@ -1,20 +1,21 @@
-
 from setuptools import setup
 import versioneer
+
 commands = versioneer.get_cmdclass().copy()
 
-setup(name="demoapp2",
-      version=versioneer.get_version(),
-      description="Demo",
-      url="url",
-      author="author",
-      author_email="email",
-      zip_safe=True,
-      packages=["demo"],
-      package_dir={"": "src"},
-      entry_points={
-          'console_scripts': [ 'rundemo = demo.main:run' ],
-          },
-      install_requires=["demolib==1.0"],
-      cmdclass=commands,
-      )
+setup(
+    name="demoapp2",
+    version=versioneer.get_version(),
+    description="Demo",
+    url="url",
+    author="author",
+    author_email="email",
+    zip_safe=True,
+    packages=["demo"],
+    package_dir={"": "src"},
+    entry_points={
+        "console_scripts": ["rundemo = demo.main:run"],
+    },
+    install_requires=["demolib==1.0"],
+    cmdclass=commands,
+)

--- a/test/demoapp2-setuptools/src/demo/main.py
+++ b/test/demoapp2-setuptools/src/demo/main.py
@@ -4,10 +4,11 @@ import demo
 from demo import _version
 from demolib import __version__ as libversion
 
+
 def run(*args, **kwargs):
     print("__version__:%s" % demo.__version__)
     print("_version:%s" % str(_version))
     versions = _version.get_versions()
     for k in sorted(versions.keys()):
-        print("%s:%s" % (k,versions[k]))
+        print("%s:%s" % (k, versions[k]))
     print("demolib:%s" % libversion)

--- a/test/demoappext-setuptools/demo/main.py
+++ b/test/demoappext-setuptools/demo/main.py
@@ -4,10 +4,11 @@ import demo
 from demo import _version
 from demolib import __version__ as libversion
 
+
 def run(*args, **kwargs):
     print("__version__:%s" % demo.__version__)
     print("_version:%s" % str(_version))
     versions = _version.get_versions()
     for k in sorted(versions.keys()):
-        print("%s:%s" % (k,versions[k]))
+        print("%s:%s" % (k, versions[k]))
     print("demolib:%s" % libversion)

--- a/test/demoappext-setuptools/setup.py
+++ b/test/demoappext-setuptools/setup.py
@@ -1,25 +1,27 @@
-
 from setuptools import setup, Extension
 import versioneer
+
 commands = versioneer.get_cmdclass().copy()
 
-extension = Extension('demo.ext',
-                      sources=['demo/ext.c'],
+extension = Extension(
+    "demo.ext",
+    sources=["demo/ext.c"],
 )
 
-setup(name="demoappext",
-      version=versioneer.get_version(),
-      description="Demo",
-      url="url",
-      author="author",
-      author_email="email",
-      zip_safe=True,
-      packages=["demo"],
-      # package_dir={"": "src"},
-      entry_points={
-          'console_scripts': [ 'rundemo = demo.main:run' ],
-          },
-      install_requires=["demolib==1.0"],
-      cmdclass=commands,
-      ext_modules=[extension],
-      )
+setup(
+    name="demoappext",
+    version=versioneer.get_version(),
+    description="Demo",
+    url="url",
+    author="author",
+    author_email="email",
+    zip_safe=True,
+    packages=["demo"],
+    # package_dir={"": "src"},
+    entry_points={
+        "console_scripts": ["rundemo = demo.main:run"],
+    },
+    install_requires=["demolib==1.0"],
+    cmdclass=commands,
+    ext_modules=[extension],
+)

--- a/test/demolib/setup.py
+++ b/test/demolib/setup.py
@@ -1,16 +1,17 @@
-
 from setuptools import setup
 import versioneer
+
 commands = versioneer.get_cmdclass().copy()
 
-setup(name="demolib",
-      version=versioneer.get_version(),
-      description="Demo",
-      url="url",
-      author="author",
-      author_email="email",
-      zip_safe=True,
-      packages=["demolib"],
-      package_dir={"": "src"},
-      cmdclass=commands,
-      )
+setup(
+    name="demolib",
+    version=versioneer.get_version(),
+    description="Demo",
+    url="url",
+    author="author",
+    author_email="email",
+    zip_safe=True,
+    packages=["demolib"],
+    package_dir={"": "src"},
+    cmdclass=commands,
+)

--- a/test/git/common.py
+++ b/test/git/common.py
@@ -5,6 +5,7 @@ GITS = ["git"]
 if sys.platform == "win32":
     GITS = ["git.cmd", "git.exe"]
 
+
 class Common:
     def command(self, cmd, *args, **kwargs):
         workdir = kwargs.pop("workdir", self.projdir)
@@ -21,8 +22,9 @@ class Common:
         env["EMAIL"] = "foo@example.com"
         env["GIT_AUTHOR_NAME"] = "foo"
         env["GIT_COMMITTER_NAME"] = "foo"
-        output, rc = run_command(GITS, args=list(args), cwd=workdir,
-                                 verbose=True, env=env)
+        output, rc = run_command(
+            GITS, args=list(args), cwd=workdir, verbose=True, env=env
+        )
         if output is None:
             self.fail("problem running git (workdir: %s)" % workdir)
         return output

--- a/test/git/test_git.py
+++ b/test/git/test_git.py
@@ -15,6 +15,7 @@ from render import render
 from git import from_vcs, from_keywords
 from subprocess_helper import run_command
 
+
 class ParseGitDescribe(unittest.TestCase):
     def setUp(self):
         self.fakeroot = tempfile.mkdtemp()
@@ -22,13 +23,12 @@ class ParseGitDescribe(unittest.TestCase):
         os.mkdir(self.fakegit)
 
     def test_pieces(self):
-        def pv(git_describe, do_error=False,
-               expect_pieces=False, branch_name="master"):
+        def pv(git_describe, do_error=False, expect_pieces=False, branch_name="master"):
             def fake_run_command(exes, args, cwd=None, hide_stderr=None):
                 if args[0] == "describe":
                     if do_error == "describe":
                         return None, 0
-                    return git_describe+"\n", 0
+                    return git_describe + "\n", 0
                 if args[0] == "rev-parse":
                     if do_error == "rev-parse":
                         return None, 0
@@ -43,80 +43,137 @@ class ParseGitDescribe(unittest.TestCase):
                         return "gpg: signature\n12345\n", 0
                     return "12345\n", 0
                 if args[0] == "branch":
-                    return "* (no branch)\n" \
-                           "  contained-branch-1\n" \
-                           "  contained-branch-2", 0
+                    return (
+                        "* (no branch)\n"
+                        "  contained-branch-1\n"
+                        "  contained-branch-2",
+                        0,
+                    )
                 self.fail("git called in weird way: %s" % (args,))
+
             return from_vcs.git_pieces_from_vcs(
-                "v", self.fakeroot, verbose=False,
-                runner=fake_run_command)
-        self.assertRaises(from_vcs.NotThisMethod,
-                          pv, "ignored", do_error="describe")
-        self.assertRaises(from_vcs.NotThisMethod,
-                          pv, "ignored", do_error="rev-parse")
-        self.assertEqual(pv("1f"),
-                         {"closest-tag": None, "dirty": False, "error": None,
-                          "distance": 42,
-                          "long": "longlong",
-                          "short": "longlon",
-                          "date": "12345",
-                          "branch": "master"})
-        self.assertEqual(pv("1f", do_error="show"),
-                         {"closest-tag": None, "dirty": False, "error": None,
-                          "distance": 42,
-                          "long": "longlong",
-                          "short": "longlon",
-                          "date": "12345",
-                          "branch": "master"})
-        self.assertEqual(pv("1f-dirty"),
-                         {"closest-tag": None, "dirty": True, "error": None,
-                          "distance": 42,
-                          "long": "longlong",
-                          "short": "longlon",
-                          "date": "12345",
-                          "branch": "master"})
-        self.assertEqual(pv("v1.0-0-g1f"),
-                         {"closest-tag": "1.0", "dirty": False, "error": None,
-                          "distance": 0,
-                          "long": "longlong",
-                          "short": "1f",
-                          "date": "12345",
-                          "branch": "master"})
-        self.assertEqual(pv("v1.0-0-g1f-dirty"),
-                         {"closest-tag": "1.0", "dirty": True, "error": None,
-                          "distance": 0,
-                          "long": "longlong",
-                          "short": "1f",
-                          "date": "12345",
-                          "branch": "master"})
-        self.assertEqual(pv("v1.0-1-g1f"),
-                         {"closest-tag": "1.0", "dirty": False, "error": None,
-                          "distance": 1,
-                          "long": "longlong",
-                          "short": "1f",
-                          "date": "12345",
-                          "branch": "master"})
-        self.assertEqual(pv("v1.0-1-g1f-dirty"),
-                         {"closest-tag": "1.0", "dirty": True, "error": None,
-                          "distance": 1,
-                          "long": "longlong",
-                          "short": "1f",
-                          "date": "12345",
-                          "branch": "master"})
-        self.assertEqual(pv("v1.0-1-g1f-dirty", branch_name="feature-branch"),
-                         {"closest-tag": "1.0", "dirty": True, "error": None,
-                          "distance": 1,
-                          "long": "longlong",
-                          "short": "1f",
-                          "date": "12345",
-                          "branch": "feature-branch"})
-        self.assertEqual(pv("v1.0-1-g1f-dirty", branch_name="HEAD"),
-                         {"closest-tag": "1.0", "dirty": True, "error": None,
-                          "distance": 1,
-                          "long": "longlong",
-                          "short": "1f",
-                          "date": "12345",
-                          "branch": "contained-branch-1"})
+                "v", self.fakeroot, verbose=False, runner=fake_run_command
+            )
+
+        self.assertRaises(from_vcs.NotThisMethod, pv, "ignored", do_error="describe")
+        self.assertRaises(from_vcs.NotThisMethod, pv, "ignored", do_error="rev-parse")
+        self.assertEqual(
+            pv("1f"),
+            {
+                "closest-tag": None,
+                "dirty": False,
+                "error": None,
+                "distance": 42,
+                "long": "longlong",
+                "short": "longlon",
+                "date": "12345",
+                "branch": "master",
+            },
+        )
+        self.assertEqual(
+            pv("1f", do_error="show"),
+            {
+                "closest-tag": None,
+                "dirty": False,
+                "error": None,
+                "distance": 42,
+                "long": "longlong",
+                "short": "longlon",
+                "date": "12345",
+                "branch": "master",
+            },
+        )
+        self.assertEqual(
+            pv("1f-dirty"),
+            {
+                "closest-tag": None,
+                "dirty": True,
+                "error": None,
+                "distance": 42,
+                "long": "longlong",
+                "short": "longlon",
+                "date": "12345",
+                "branch": "master",
+            },
+        )
+        self.assertEqual(
+            pv("v1.0-0-g1f"),
+            {
+                "closest-tag": "1.0",
+                "dirty": False,
+                "error": None,
+                "distance": 0,
+                "long": "longlong",
+                "short": "1f",
+                "date": "12345",
+                "branch": "master",
+            },
+        )
+        self.assertEqual(
+            pv("v1.0-0-g1f-dirty"),
+            {
+                "closest-tag": "1.0",
+                "dirty": True,
+                "error": None,
+                "distance": 0,
+                "long": "longlong",
+                "short": "1f",
+                "date": "12345",
+                "branch": "master",
+            },
+        )
+        self.assertEqual(
+            pv("v1.0-1-g1f"),
+            {
+                "closest-tag": "1.0",
+                "dirty": False,
+                "error": None,
+                "distance": 1,
+                "long": "longlong",
+                "short": "1f",
+                "date": "12345",
+                "branch": "master",
+            },
+        )
+        self.assertEqual(
+            pv("v1.0-1-g1f-dirty"),
+            {
+                "closest-tag": "1.0",
+                "dirty": True,
+                "error": None,
+                "distance": 1,
+                "long": "longlong",
+                "short": "1f",
+                "date": "12345",
+                "branch": "master",
+            },
+        )
+        self.assertEqual(
+            pv("v1.0-1-g1f-dirty", branch_name="feature-branch"),
+            {
+                "closest-tag": "1.0",
+                "dirty": True,
+                "error": None,
+                "distance": 1,
+                "long": "longlong",
+                "short": "1f",
+                "date": "12345",
+                "branch": "feature-branch",
+            },
+        )
+        self.assertEqual(
+            pv("v1.0-1-g1f-dirty", branch_name="HEAD"),
+            {
+                "closest-tag": "1.0",
+                "dirty": True,
+                "error": None,
+                "distance": 1,
+                "long": "longlong",
+                "short": "1f",
+                "date": "12345",
+                "branch": "contained-branch-1",
+            },
+        )
 
     def tearDown(self):
         os.rmdir(self.fakegit)
@@ -126,7 +183,8 @@ class ParseGitDescribe(unittest.TestCase):
 class Keywords(unittest.TestCase):
     def parse(self, refnames, full, prefix="", date=None):
         return from_keywords.git_versions_from_keywords(
-            {"refnames": refnames, "full": full, "date": date}, prefix, False)
+            {"refnames": refnames, "full": full, "date": date}, prefix, False
+        )
 
     def test_parse(self):
         v = self.parse(" (HEAD, 2.0,master  , otherbranch ) ", " full ")
@@ -153,8 +211,13 @@ class Keywords(unittest.TestCase):
         self.assertEqual(v["date"], None)
 
     def test_unexpanded(self):
-        self.assertRaises(from_keywords.NotThisMethod,
-                          self.parse, " $Format$ ", " full ", "projectname-")
+        self.assertRaises(
+            from_keywords.NotThisMethod,
+            self.parse,
+            " $Format$ ",
+            " full ",
+            "projectname-",
+        )
 
     def test_no_tags(self):
         v = self.parse("(HEAD, master)", "full")
@@ -175,8 +238,7 @@ class Keywords(unittest.TestCase):
     def test_date(self):
         date = "2017-07-24 16:03:40 +0200"
         result = "2017-07-24T16:03:40+0200"
-        v = self.parse(" (HEAD, 2.0,master  , otherbranch ) ", " full ",
-                       date=date)
+        v = self.parse(" (HEAD, 2.0,master  , otherbranch ) ", " full ", date=date)
         self.assertEqual(v["date"], result)
 
     def test_date_gpg(self):
@@ -185,9 +247,9 @@ class Keywords(unittest.TestCase):
         gpg: ...
         2017-07-24 16:03:40 +0200"""
         result = "2017-07-24T16:03:40+0200"
-        v = self.parse(" (HEAD, 2.0,master  , otherbranch ) ", " full ",
-                       date=date)
+        v = self.parse(" (HEAD, 2.0,master  , otherbranch ) ", " full ", date=date)
         self.assertEqual(v["date"], result)
+
 
 expected_renders = """
 closest-tag: 1.0
@@ -298,12 +360,20 @@ git-describe-long: 250b7ca-dirty
 
 """
 
+
 class RenderPieces(unittest.TestCase):
     def do_render(self, pieces):
         out = {}
-        for style in ["pep440", "pep440-branch", "pep440-pre", "pep440-post",
-                      "pep440-post-branch", "pep440-old", "git-describe",
-                      "git-describe-long"]:
+        for style in [
+            "pep440",
+            "pep440-branch",
+            "pep440-pre",
+            "pep440-post",
+            "pep440-post-branch",
+            "pep440-old",
+            "git-describe",
+            "git-describe-long",
+        ]:
             out[style] = render(pieces, style)["version"]
         DEFAULT = "pep440"
         self.assertEqual(render(pieces, ""), render(pieces, DEFAULT))
@@ -311,9 +381,11 @@ class RenderPieces(unittest.TestCase):
         return out
 
     def parse_expected(self):
-        base_pieces = {"long": "250b7ca731388d8f016db2e06ab1d6289486424b",
-                       "short": "250b7ca",
-                       "error": None}
+        base_pieces = {
+            "long": "250b7ca731388d8f016db2e06ab1d6289486424b",
+            "short": "250b7ca",
+            "error": None,
+        }
         more_pieces = {}
         expected = {}
         for line in expected_renders.splitlines():
@@ -350,11 +422,13 @@ class RenderPieces(unittest.TestCase):
         for (pieces, expected) in self.parse_expected():
             got = self.do_render(pieces)
             for key in expected:
-                self.assertEqual(got[key], expected[key],
-                                 (pieces, key, got[key], expected[key]))
+                self.assertEqual(
+                    got[key], expected[key], (pieces, key, got[key], expected[key])
+                )
 
 
 VERBOSE = False
+
 
 class Repo(common.Common, unittest.TestCase):
 
@@ -409,7 +483,8 @@ class Repo(common.Common, unittest.TestCase):
         # .git parent. So if you change this to use a fixed directory (say,
         # when debugging problems), use /tmp/_test rather than ./_test .
         self.testdir = tempfile.mkdtemp()
-        if VERBOSE: print("testdir: %s" % (self.testdir,))
+        if VERBOSE:
+            print("testdir: %s" % (self.testdir,))
         if os.path.exists(self.testdir):
             shutil.rmtree(self.testdir)
 
@@ -421,8 +496,7 @@ class Repo(common.Common, unittest.TestCase):
         # self.command() operations run from this directory unless
         # overridden.
         self.project_sub_dir = project_sub_dir
-        self.projdir = os.path.join(self.testdir, self.gitdir,
-                                    self.project_sub_dir)
+        self.projdir = os.path.join(self.testdir, self.gitdir, self.project_sub_dir)
 
         os.mkdir(self.testdir)
 
@@ -441,8 +515,9 @@ class Repo(common.Common, unittest.TestCase):
         full = self.git("rev-parse", "HEAD")
         v = self.python("setup.py", "--version")
         self.assertEqual(v, "0+untagged.1.g%s" % full[:7])
-        v = self.python(self.project_file("setup.py"), "--version",
-                        workdir=self.testdir)
+        v = self.python(
+            self.project_file("setup.py"), "--version", workdir=self.testdir
+        )
         self.assertEqual(v, "0+untagged.1.g%s" % full[:7])
 
         out = self.python("versioneer.py", "setup").splitlines()
@@ -452,23 +527,33 @@ class Repo(common.Common, unittest.TestCase):
         else:
             self.assertEqual(out[1], " appending to src/demo/__init__.py")
         self.assertEqual(out[2], " appending 'versioneer.py' to MANIFEST.in")
-        self.assertEqual(out[3], " appending versionfile_source ('src/demo/_version.py') to MANIFEST.in")
+        self.assertEqual(
+            out[3],
+            " appending versionfile_source ('src/demo/_version.py') to MANIFEST.in",
+        )
 
         # Many folks have a ~/.gitignore with ignores .pyc files, but if they
         # don't, it will show up in the status here. Ignore it.
         def remove_pyc(s):
-            return [f for f in s
-                    if not (f.startswith("?? ")
-                            and (f.endswith(".pyc") or
-                                 f.endswith("__pycache__/")))
-                    ]
+            return [
+                f
+                for f in s
+                if not (
+                    f.startswith("?? ")
+                    and (f.endswith(".pyc") or f.endswith("__pycache__/"))
+                )
+            ]
+
         out = set(remove_pyc(self.git("status", "--porcelain").splitlines()))
+
         def pf(fn):
             return os.path.normpath(os.path.join(self.project_sub_dir, fn))
-        expected = {"A  %s" % pf(".gitattributes"),
-                    "M  %s" % pf("MANIFEST.in"),
-                    "A  %s" % pf("src/demo/_version.py"),
-                    }
+
+        expected = {
+            "A  %s" % pf(".gitattributes"),
+            "M  %s" % pf("MANIFEST.in"),
+            "A  %s" % pf("src/demo/_version.py"),
+        }
         if not script_only:
             expected.add("M  %s" % pf("src/demo/__init__.py"))
         self.assertEqual(out, expected)
@@ -497,12 +582,16 @@ class Repo(common.Common, unittest.TestCase):
         # S1: the tree is sitting on a pre-tagged commit
         full = self.git("rev-parse", "HEAD")
         short = "0+untagged.2.g%s" % full[:7]
-        self.do_checks("S1", {"TA": [short, full, False, None],
-                              "TB": ["0+unknown", None, None, UNABLE],
-                              "TC": [short, full, False, None],
-                              "TD": ["0+unknown", full, False, NOTAG],
-                              "TE": [short, full, False, None],
-                              })
+        self.do_checks(
+            "S1",
+            {
+                "TA": [short, full, False, None],
+                "TB": ["0+unknown", None, None, UNABLE],
+                "TC": [short, full, False, None],
+                "TD": ["0+unknown", full, False, NOTAG],
+                "TE": [short, full, False, None],
+            },
+        )
 
         # TD: expanded keywords only tell us about tags and full revisionids,
         # not how many patches we are beyond a tag. So any TD git-archive
@@ -515,12 +604,16 @@ class Repo(common.Common, unittest.TestCase):
             fobj.write("# dirty\n")
         full = self.git("rev-parse", "HEAD")
         short = "0+untagged.2.g%s.dirty" % full[:7]
-        self.do_checks("S2", {"TA": [short, full, True, None],
-                              "TB": ["0+unknown", None, None, UNABLE],
-                              "TC": [short, full, True, None],
-                              "TD": ["0+unknown", full, False, NOTAG],
-                              "TE": [short, full, True, None],
-                              })
+        self.do_checks(
+            "S2",
+            {
+                "TA": [short, full, True, None],
+                "TB": ["0+unknown", None, None, UNABLE],
+                "TC": [short, full, True, None],
+                "TD": ["0+unknown", full, False, NOTAG],
+                "TE": [short, full, True, None],
+            },
+        )
 
         # S3: we commit that change, then make the first tag (1.0)
         self.git("add", self.project_file("setup.py"))
@@ -532,51 +625,67 @@ class Repo(common.Common, unittest.TestCase):
         self.git("tag", "aaa-999")
         full = self.git("rev-parse", "HEAD")
         short = "1.0"
-        if VERBOSE: print("FULL %s" % full)
+        if VERBOSE:
+            print("FULL %s" % full)
         # the tree is now sitting on the 1.0 tag
-        self.do_checks("S3", {"TA": [short, full, False, None],
-                              "TB": ["0+unknown", None, None, UNABLE],
-                              "TC": [short, full, False, None],
-                              "TD": [short, full, False, None],
-                              "TE": [short, full, False, None],
-                              })
+        self.do_checks(
+            "S3",
+            {
+                "TA": [short, full, False, None],
+                "TB": ["0+unknown", None, None, UNABLE],
+                "TC": [short, full, False, None],
+                "TD": [short, full, False, None],
+                "TE": [short, full, False, None],
+            },
+        )
 
         # S4: now we dirty the tree
         with open(self.project_file("setup.py"), "a") as fobj:
             fobj.write("# dirty\n")
         full = self.git("rev-parse", "HEAD")
         short = "1.0+0.g%s.dirty" % full[:7]
-        self.do_checks("S4", {"TA": [short, full, True, None],
-                              "TB": ["0+unknown", None, None, UNABLE],
-                              "TC": [short, full, True, None],
-                              "TD": ["1.0", full, False, None],
-                              "TE": [short, full, True, None],
-                              })
+        self.do_checks(
+            "S4",
+            {
+                "TA": [short, full, True, None],
+                "TB": ["0+unknown", None, None, UNABLE],
+                "TC": [short, full, True, None],
+                "TD": ["1.0", full, False, None],
+                "TE": [short, full, True, None],
+            },
+        )
 
         # S5: now we make one commit past the tag
         self.git("add", self.project_file("setup.py"))
         self.git("commit", "-m", "dirty")
         full = self.git("rev-parse", "HEAD")
         short = "1.0+1.g%s" % full[:7]
-        self.do_checks("S5", {"TA": [short, full, False, None],
-                              "TB": ["0+unknown", None, None, UNABLE],
-                              "TC": [short, full, False, None],
-                              "TD": ["0+unknown", full, False, NOTAG],
-                              "TE": [short, full, False, None],
-                              })
+        self.do_checks(
+            "S5",
+            {
+                "TA": [short, full, False, None],
+                "TB": ["0+unknown", None, None, UNABLE],
+                "TC": [short, full, False, None],
+                "TD": ["0+unknown", full, False, NOTAG],
+                "TE": [short, full, False, None],
+            },
+        )
 
         # S6: dirty the post-tag tree
         with open(self.project_file("setup.py"), "a") as fobj:
             fobj.write("# more dirty\n")
         full = self.git("rev-parse", "HEAD")
         short = "1.0+1.g%s.dirty" % full[:7]
-        self.do_checks("S6", {"TA": [short, full, True, None],
-                              "TB": ["0+unknown", None, None, UNABLE],
-                              "TC": [short, full, True, None],
-                              "TD": ["0+unknown", full, False, NOTAG],
-                              "TE": [short, full, True, None],
-                              })
-
+        self.do_checks(
+            "S6",
+            {
+                "TA": [short, full, True, None],
+                "TB": ["0+unknown", None, None, UNABLE],
+                "TC": [short, full, True, None],
+                "TD": ["0+unknown", full, False, NOTAG],
+                "TE": [short, full, True, None],
+            },
+        )
 
     def do_checks(self, state, exps):
         if os.path.exists(self.subpath("out")):
@@ -596,17 +705,23 @@ class Repo(common.Common, unittest.TestCase):
         shutil.copytree(self.projdir, target)
         if os.path.exists(os.path.join(target, ".git")):
             shutil.rmtree(os.path.join(target, ".git"))
-        self.check_version(target, state, "TC", ["1.1", None, False, None]) # XXX
+        self.check_version(target, state, "TC", ["1.1", None, False, None])  # XXX
 
         # TD: project subdir of an unpacked git-archive tarball
         target = self.subpath("out/TD/demoapp-TD")
-        self.git("archive", "--format=tar", "--prefix=demoapp-TD/",
-                 "--output=../demo.tar", "HEAD")
+        self.git(
+            "archive",
+            "--format=tar",
+            "--prefix=demoapp-TD/",
+            "--output=../demo.tar",
+            "HEAD",
+        )
         os.mkdir(self.subpath("out/TD"))
         with tarfile.TarFile(self.subpath("demo.tar")) as t:
             t.extractall(path=self.subpath("out/TD"))
-        self.check_version(os.path.join(target, self.project_sub_dir),
-                           state, "TD", exps["TD"])
+        self.check_version(
+            os.path.join(target, self.project_sub_dir), state, "TD", exps["TD"]
+        )
 
         # TE: unpacked setup.py sdist tarball
         dist_path = os.path.join(self.projdir, "dist")
@@ -614,7 +729,7 @@ class Repo(common.Common, unittest.TestCase):
             shutil.rmtree(dist_path)
         self.python("setup.py", "sdist", "--formats=tar")
         files = os.listdir(dist_path)
-        self.assertTrue(len(files)==1, files)
+        self.assertTrue(len(files) == 1, files)
         distfile = files[0]
         self.assertEqual(distfile, "demo-%s.tar" % exps["TE"][0])
         fn = os.path.join(dist_path, distfile)
@@ -627,7 +742,8 @@ class Repo(common.Common, unittest.TestCase):
 
     def check_version(self, workdir, state, tree, exps):
         exp_version, exp_full, exp_dirty, exp_error = exps
-        if VERBOSE: print("== starting %s %s" % (state, tree))
+        if VERBOSE:
+            print("== starting %s %s" % (state, tree))
         # RA: setup.py --version
         if VERBOSE:
             # setup.py version invokes cmd_version, which uses verbose=True
@@ -639,19 +755,25 @@ class Repo(common.Common, unittest.TestCase):
         self.assertPEP440(v, state, tree, "RA1")
 
         # and test again from outside the tree
-        v = self.python(os.path.join(workdir, "setup.py"), "--version",
-                        workdir=self.testdir)
+        v = self.python(
+            os.path.join(workdir, "setup.py"), "--version", workdir=self.testdir
+        )
         self.compare(v, exp_version, state, tree, "RA2")
         self.assertPEP440(v, state, tree, "RA2")
 
         # RB: setup.py build; rundemo --version
         if os.path.exists(os.path.join(workdir, "build")):
             shutil.rmtree(os.path.join(workdir, "build"))
-        self.python("setup.py", "build", "--build-lib=build/lib",
-                    "--build-scripts=build/lib", workdir=workdir)
+        self.python(
+            "setup.py",
+            "build",
+            "--build-lib=build/lib",
+            "--build-scripts=build/lib",
+            workdir=workdir,
+        )
         build_lib = os.path.join(workdir, "build", "lib")
         out = self.python("rundemo", "--version", workdir=build_lib)
-        data = dict(line.split(":",1) for line in out.splitlines())
+        data = dict(line.split(":", 1) for line in out.splitlines())
         self.compare(data["__version__"], exp_version, state, tree, "RB")
         self.assertPEP440(data["__version__"], state, tree, "RB")
         self.compare(data["version"], exp_version, state, tree, "RB")
@@ -661,22 +783,26 @@ class Repo(common.Common, unittest.TestCase):
 
     def compare(self, got, expected, state, tree, runtime):
         where = "/".join([state, tree, runtime])
-        self.assertEqual(got, expected, "%s: got '%s' != expected '%s'"
-                         % (where, got, expected))
-        if VERBOSE: print(" good %s" % where)
+        self.assertEqual(
+            got, expected, "%s: got '%s' != expected '%s'" % (where, got, expected)
+        )
+        if VERBOSE:
+            print(" good %s" % where)
 
     def assertPEP440(self, got, state, tree, runtime):
         where = "/".join([state, tree, runtime])
         pv = parse_version(got)
         # rather than using an undocumented API, setuptools dev recommends this
-        self.assertFalse("Legacy" in pv.__class__.__name__,
-                         "%s: '%s' was not pep440-compatible"
-                         % (where, got))
-        self.assertEqual(str(pv), got,
-                         "%s: '%s' pep440-normalized to '%s'"
-                         % (where, got, str(pv)))
+        self.assertFalse(
+            "Legacy" in pv.__class__.__name__,
+            "%s: '%s' was not pep440-compatible" % (where, got),
+        )
+        self.assertEqual(
+            str(pv), got, "%s: '%s' pep440-normalized to '%s'" % (where, got, str(pv))
+        )
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     ver, rc = run_command(common.GITS, ["--version"], ".", True)
     print("git --version: %s" % ver.strip())
     unittest.main()

--- a/test/git/test_invocations.py
+++ b/test/git/test_invocations.py
@@ -53,21 +53,22 @@ class _Invocations(common.Common):
         # switching to 'venv' on py3, but only py3.4 includes pip, and even
         # then it's an ancient version.
         os.environ.pop("__PYVENV_LAUNCHER__", None)
-        virtualenv.logger = virtualenv.Logger([]) # hush
+        virtualenv.logger = virtualenv.Logger([])  # hush
         # virtualenv causes DeprecationWarning/ResourceWarning on py3
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             virtualenv.create_environment(venv_dir)
-            self.run_in_venv(venv_dir, venv_dir,
-                             'pip', 'install', '-U',
-                             'pip', 'wheel', 'packaging')
+            self.run_in_venv(
+                venv_dir, venv_dir, "pip", "install", "-U", "pip", "wheel", "packaging"
+            )
         return venv_dir
 
     def run_in_venv(self, venv, workdir, command, *args):
-        bins = {"python": os.path.join(venv, "bin", "python"),
-                "pip": os.path.join(venv, "bin", "pip"),
-                "rundemo": os.path.join(venv, "bin", "rundemo"),
-                }
+        bins = {
+            "python": os.path.join(venv, "bin", "python"),
+            "pip": os.path.join(venv, "bin", "pip"),
+            "rundemo": os.path.join(venv, "bin", "rundemo"),
+        }
         if command == "pip":
             args = ["--isolated", "--no-cache-dir"] + list(args)
         return self.command(bins[command], *args, workdir=workdir)
@@ -169,10 +170,16 @@ class _Invocations(common.Common):
             return demoapp2_distutils_wheel
         repodir = self.make_distutils_repo()
         venv = self.make_venv("make-distutils-wheel-with-pip")
-        self.run_in_venv(venv, repodir,
-                         "pip", "wheel", "--wheel-dir", "wheelhouse",
-                         "--no-index",# "--find-links", linkdir,
-                         ".")
+        self.run_in_venv(
+            venv,
+            repodir,
+            "pip",
+            "wheel",
+            "--wheel-dir",
+            "wheelhouse",
+            "--no-index",  # "--find-links", linkdir,
+            ".",
+        )
         created = os.path.join(repodir, "wheelhouse", wheelname)
         self.assertTrue(os.path.exists(created), created)
         shutil.copyfile(created, demoapp2_distutils_wheel)
@@ -180,8 +187,9 @@ class _Invocations(common.Common):
 
     def make_distutils_sdist(self):
         # create an sdist tarball of demoapp2-distutils at 2.0
-        demoapp2_distutils_sdist = self.subpath("cache", "distutils",
-                                                "demoapp2-2.0.tar")
+        demoapp2_distutils_sdist = self.subpath(
+            "cache", "distutils", "demoapp2-2.0.tar"
+        )
         if os.path.exists(demoapp2_distutils_sdist):
             return demoapp2_distutils_sdist
         repodir = self.make_distutils_repo()
@@ -192,8 +200,9 @@ class _Invocations(common.Common):
         return demoapp2_distutils_sdist
 
     def make_distutils_sdist_subproject(self):
-        demoapp2_distutils_sdist = self.subpath("cache", "distutils",
-                                                "demoapp2-subproject-2.0.tar")
+        demoapp2_distutils_sdist = self.subpath(
+            "cache", "distutils", "demoapp2-subproject-2.0.tar"
+        )
         if os.path.exists(demoapp2_distutils_sdist):
             return demoapp2_distutils_sdist
         projectdir = self.make_distutils_repo_subproject()
@@ -257,8 +266,9 @@ class _Invocations(common.Common):
 
     def make_setuptools_extension_sdist(self):
         # create an sdist tarball of demoappext-setuptools at 2.0
-        demoappext_setuptools_sdist = self.subpath("cache", "setuptools",
-                                                   "demoappext-2.0.tar")
+        demoappext_setuptools_sdist = self.subpath(
+            "cache", "setuptools", "demoappext-2.0.tar"
+        )
         if os.path.exists(demoappext_setuptools_sdist):
             return demoappext_setuptools_sdist
         repodir = self.make_setuptools_extension_repo()
@@ -300,8 +310,9 @@ class _Invocations(common.Common):
 
     def make_setuptools_sdist(self):
         # create an sdist tarball of demoapp2-setuptools at 2.0
-        demoapp2_setuptools_sdist = self.subpath("cache", "setuptools",
-                                                 "demoapp2-2.0.tar")
+        demoapp2_setuptools_sdist = self.subpath(
+            "cache", "setuptools", "demoapp2-2.0.tar"
+        )
         if os.path.exists(demoapp2_setuptools_sdist):
             return demoapp2_setuptools_sdist
         repodir = self.make_setuptools_repo()
@@ -312,8 +323,9 @@ class _Invocations(common.Common):
         return demoapp2_setuptools_sdist
 
     def make_setuptools_sdist_subproject(self):
-        demoapp2_setuptools_sdist = self.subpath("cache", "setuptools",
-                                                 "demoapp2-subproject-2.0.tar")
+        demoapp2_setuptools_sdist = self.subpath(
+            "cache", "setuptools", "demoapp2-subproject-2.0.tar"
+        )
         if os.path.exists(demoapp2_setuptools_sdist):
             return demoapp2_setuptools_sdist
         projectdir = self.make_setuptools_repo_subproject()
@@ -349,8 +361,9 @@ class _Invocations(common.Common):
 
     def make_setuptools_egg(self):
         # create an egg of demoapp2-setuptools at 2.0
-        demoapp2_setuptools_egg = self.subpath("cache", "setuptools",
-                                               "demoapp2-2.0-%s.egg" % pyver)
+        demoapp2_setuptools_egg = self.subpath(
+            "cache", "setuptools", "demoapp2-2.0-%s.egg" % pyver
+        )
         if os.path.exists(demoapp2_setuptools_egg):
             return demoapp2_setuptools_egg
         repodir = self.make_setuptools_repo()
@@ -363,8 +376,7 @@ class _Invocations(common.Common):
     def make_setuptools_wheel_with_setup_py(self):
         # create an wheel of demoapp2-setuptools at 2.0
         wheelname = "demoapp2-2.0-%s-none-any.whl" % pyver_major
-        demoapp2_setuptools_wheel = self.subpath("cache", "setuptools",
-                                                 wheelname)
+        demoapp2_setuptools_wheel = self.subpath("cache", "setuptools", wheelname)
         if os.path.exists(demoapp2_setuptools_wheel):
             # there are two ways to make this .whl, and we need to exercise
             # both, so don't actually cache the results
@@ -379,8 +391,7 @@ class _Invocations(common.Common):
     def make_setuptools_wheel_with_pip(self):
         # create an wheel of demoapp2-setuptools at 2.0
         wheelname = "demoapp2-2.0-%s-none-any.whl" % pyver_major
-        demoapp2_setuptools_wheel = self.subpath("cache", "setuptools",
-                                                 wheelname)
+        demoapp2_setuptools_wheel = self.subpath("cache", "setuptools", wheelname)
         if os.path.exists(demoapp2_setuptools_wheel):
             # there are two ways to make this .whl, and we need to exercise
             # both, so don't actually cache the results
@@ -388,18 +399,30 @@ class _Invocations(common.Common):
         linkdir = self.make_linkdir()
         repodir = self.make_setuptools_repo()
         venv = self.make_venv("make-setuptools-wheel-with-pip")
-        self.run_in_venv(venv, repodir,
-                         "pip", "wheel", "--wheel-dir", "wheelhouse",
-                         "--no-index", "--find-links", linkdir,
-                         ".")
+        self.run_in_venv(
+            venv,
+            repodir,
+            "pip",
+            "wheel",
+            "--wheel-dir",
+            "wheelhouse",
+            "--no-index",
+            "--find-links",
+            linkdir,
+            ".",
+        )
         created = os.path.join(repodir, "wheelhouse", wheelname)
         self.assertTrue(os.path.exists(created), created)
         shutil.copyfile(created, demoapp2_setuptools_wheel)
         return demoapp2_setuptools_wheel
 
     def make_binary_wheelname(self, app):
-        return "%s-2.0-%s-%s-%s.whl" % (app,
-            "".join([impl, impl_ver]), abi, plat.replace("-", "_"))
+        return "%s-2.0-%s-%s-%s.whl" % (
+            app,
+            "".join([impl, impl_ver]),
+            abi,
+            plat.replace("-", "_"),
+        )
 
 
 class DistutilsRepo(_Invocations, unittest.TestCase):
@@ -430,18 +453,20 @@ class DistutilsRepo(_Invocations, unittest.TestCase):
         # asserts version as a side-effect
 
     def test_sdist(self):
-        sdist = self.make_distutils_sdist() # asserts version as a side-effect
+        sdist = self.make_distutils_sdist()  # asserts version as a side-effect
         # make sure we used distutils/sdist, not setuptools/sdist
         with tarfile.TarFile(sdist) as t:
-            self.assertFalse("demoapp2-2.0/src/demoapp2.egg-info/PKG-INFO" in
-                             t.getnames())
+            self.assertFalse(
+                "demoapp2-2.0/src/demoapp2.egg-info/PKG-INFO" in t.getnames()
+            )
 
     def test_sdist_subproject(self):
         sdist = self.make_distutils_sdist_subproject()
         # make sure we used distutils/sdist, not setuptools/sdist
         with tarfile.TarFile(sdist) as t:
-            self.assertFalse("demoapp2-2.0/src/demoapp2.egg-info/PKG-INFO" in
-                             t.getnames())
+            self.assertFalse(
+                "demoapp2-2.0/src/demoapp2.egg-info/PKG-INFO" in t.getnames()
+            )
 
     def test_pip_install(self):
         repodir = self.make_distutils_repo()
@@ -479,6 +504,7 @@ class DistutilsRepo(_Invocations, unittest.TestCase):
         self.run_in_venv(venv, projectdir, "pip", "install", "--editable", ".")
         self.check_in_venv(venv)
 
+
 class SetuptoolsRepo(_Invocations, unittest.TestCase):
     def test_install(self):
         repodir = self.make_setuptools_repo()
@@ -507,10 +533,17 @@ class SetuptoolsRepo(_Invocations, unittest.TestCase):
         venv = self.make_venv("setuptools-repo-develop")
         # "setup.py develop" takes --find-links and --index-url but not
         # --no-index
-        self.run_in_venv(venv, repodir,
-                         "python", "setup.py", "develop",
-                         "--index-url", indexdir, "--find-links", linkdir,
-                         )
+        self.run_in_venv(
+            venv,
+            repodir,
+            "python",
+            "setup.py",
+            "develop",
+            "--index-url",
+            indexdir,
+            "--find-links",
+            linkdir,
+        )
         self.check_in_venv_withlib(venv)
 
     def test_develop_subproject(self):
@@ -520,14 +553,21 @@ class SetuptoolsRepo(_Invocations, unittest.TestCase):
         venv = self.make_venv("setuptools-repo-develop-subproject")
         # "setup.py develop" takes --find-links and --index-url but not
         # --no-index
-        self.run_in_venv(venv, projectdir,
-                         "python", "setup.py", "develop",
-                         "--index-url", indexdir, "--find-links", linkdir,
-                         )
+        self.run_in_venv(
+            venv,
+            projectdir,
+            "python",
+            "setup.py",
+            "develop",
+            "--index-url",
+            indexdir,
+            "--find-links",
+            linkdir,
+        )
         self.check_in_venv_withlib(venv)
 
     def test_egg(self):
-        self.make_setuptools_egg() # asserts version as a side-effect
+        self.make_setuptools_egg()  # asserts version as a side-effect
 
     def test_pip_wheel(self):
         self.make_setuptools_wheel_with_pip()
@@ -538,7 +578,7 @@ class SetuptoolsRepo(_Invocations, unittest.TestCase):
         # asserts version as a side-effect
 
     def test_sdist(self):
-        sdist = self.make_setuptools_sdist() # asserts version as a side-effect
+        sdist = self.make_setuptools_sdist()  # asserts version as a side-effect
         # make sure we used setuptools/sdist, not distutils/sdist
         with tarfile.TarFile(sdist) as t:
             self.assertIn("demoapp2-2.0/src/demoapp2.egg-info/PKG-INFO", t.getnames())
@@ -553,96 +593,131 @@ class SetuptoolsRepo(_Invocations, unittest.TestCase):
         linkdir = self.make_linkdir()
         repodir = self.make_setuptools_repo()
         venv = self.make_venv("setuptools-repo-pip-install")
-        self.run_in_venv(venv, repodir, "pip", "install", ".",
-                         "--no-index", "--find-links", linkdir)
+        self.run_in_venv(
+            venv, repodir, "pip", "install", ".", "--no-index", "--find-links", linkdir
+        )
         self.check_in_venv_withlib(venv)
 
     def test_pip_install_subproject(self):
         linkdir = self.make_linkdir()
         projectdir = self.make_setuptools_repo_subproject()
         venv = self.make_venv("setuptools-repo-pip-install-subproject")
-        self.run_in_venv(venv, projectdir, "pip", "install", ".",
-                         "--no-index", "--find-links", linkdir)
+        self.run_in_venv(
+            venv,
+            projectdir,
+            "pip",
+            "install",
+            ".",
+            "--no-index",
+            "--find-links",
+            linkdir,
+        )
         self.check_in_venv_withlib(venv)
 
     def test_pip_install_from_afar(self):
         linkdir = self.make_linkdir()
         repodir = self.make_setuptools_repo()
         venv = self.make_venv("setuptools-repo-pip-install-from-afar")
-        self.run_in_venv(venv, venv, "pip", "install", repodir,
-                         "--no-index", "--find-links", linkdir)
+        self.run_in_venv(
+            venv, venv, "pip", "install", repodir, "--no-index", "--find-links", linkdir
+        )
         self.check_in_venv_withlib(venv)
 
     def test_pip_install_from_afar_subproject(self):
         linkdir = self.make_linkdir()
         projectdir = self.make_setuptools_repo_subproject()
         venv = self.make_venv("setuptools-repo-pip-install-from-afar-subproject")
-        self.run_in_venv(venv, venv, "pip", "install", projectdir,
-                         "--no-index", "--find-links", linkdir)
+        self.run_in_venv(
+            venv,
+            venv,
+            "pip",
+            "install",
+            projectdir,
+            "--no-index",
+            "--find-links",
+            linkdir,
+        )
         self.check_in_venv_withlib(venv)
 
     def test_pip_install_editable(self):
         linkdir = self.make_linkdir()
         repodir = self.make_setuptools_repo()
         venv = self.make_venv("setuptools-repo-pip-install-editable")
-        self.run_in_venv(venv, repodir, "pip", "install", "--editable", ".",
-                         "--no-index", "--find-links", linkdir)
+        self.run_in_venv(
+            venv,
+            repodir,
+            "pip",
+            "install",
+            "--editable",
+            ".",
+            "--no-index",
+            "--find-links",
+            linkdir,
+        )
         self.check_in_venv_withlib(venv)
 
     def test_pip_install_editable_subproject(self):
         linkdir = self.make_linkdir()
         projectdir = self.make_setuptools_repo_subproject()
         venv = self.make_venv("setuptools-repo-pip-install-editable-subproject")
-        self.run_in_venv(venv, projectdir, "pip", "install", "--editable", ".",
-                         "--no-index", "--find-links", linkdir)
+        self.run_in_venv(
+            venv,
+            projectdir,
+            "pip",
+            "install",
+            "--editable",
+            ".",
+            "--no-index",
+            "--find-links",
+            linkdir,
+        )
         self.check_in_venv_withlib(venv)
+
 
 class DistutilsSdist(_Invocations, unittest.TestCase):
     def test_pip_install(self):
         sdist = self.make_distutils_sdist()
         venv = self.make_venv("distutils-sdist-pip-install")
-        self.run_in_venv(venv, venv,
-                         "pip", "install", sdist)
+        self.run_in_venv(venv, venv, "pip", "install", sdist)
         self.check_in_venv(venv)
 
     def test_pip_install_subproject(self):
         sdist = self.make_distutils_sdist_subproject()
         venv = self.make_venv("distutils-sdist-pip-install-subproject")
-        self.run_in_venv(venv, venv,
-                         "pip", "install", sdist)
+        self.run_in_venv(venv, venv, "pip", "install", sdist)
         self.check_in_venv(venv)
+
 
 class SetuptoolsSdist(_Invocations, unittest.TestCase):
     def test_pip_install(self):
         linkdir = self.make_linkdir()
         sdist = self.make_setuptools_sdist()
         venv = self.make_venv("setuptools-sdist-pip-install")
-        self.run_in_venv(venv, venv,
-                         "pip", "install",
-                         "--no-index", "--find-links", linkdir,
-                         sdist)
+        self.run_in_venv(
+            venv, venv, "pip", "install", "--no-index", "--find-links", linkdir, sdist
+        )
         self.check_in_venv_withlib(venv)
 
     def test_pip_install_subproject(self):
         linkdir = self.make_linkdir()
         sdist = self.make_setuptools_sdist_subproject()
         venv = self.make_venv("setuptools-sdist-pip-install-subproject")
-        self.run_in_venv(venv, venv,
-                         "pip", "install",
-                         "--no-index", "--find-links", linkdir,
-                         sdist)
+        self.run_in_venv(
+            venv, venv, "pip", "install", "--no-index", "--find-links", linkdir, sdist
+        )
         self.check_in_venv_withlib(venv)
+
 
 class SetuptoolsWheel(_Invocations, unittest.TestCase):
     def test_pip_install(self):
         linkdir = self.make_linkdir()
         wheel = self.make_setuptools_wheel_with_setup_py()
         venv = self.make_venv("setuptools-wheel-pip-install")
-        self.run_in_venv(venv, venv,
-                         "pip", "install",
-                         "--no-index", "--find-links", linkdir,
-                         wheel)
+        self.run_in_venv(
+            venv, venv, "pip", "install", "--no-index", "--find-links", linkdir, wheel
+        )
         self.check_in_venv_withlib(venv)
+
 
 class DistutilsUnpacked(_Invocations, unittest.TestCase):
     def test_build(self):
@@ -671,10 +746,16 @@ class DistutilsUnpacked(_Invocations, unittest.TestCase):
         unpacked = self.make_distutils_unpacked()
         wheelname = "demoapp2-2.0-%s-none-any.whl" % pyver_major
         venv = self.make_venv("distutils-unpacked-pip-wheel")
-        self.run_in_venv(venv, unpacked,
-                         "pip", "wheel", "--wheel-dir", "wheelhouse",
-                         "--no-index",# "--find-links", linkdir,
-                         ".")
+        self.run_in_venv(
+            venv,
+            unpacked,
+            "pip",
+            "wheel",
+            "--wheel-dir",
+            "wheelhouse",
+            "--no-index",  # "--find-links", linkdir,
+            ".",
+        )
         created = os.path.join(unpacked, "wheelhouse", wheelname)
         self.assertTrue(os.path.exists(created), created)
 
@@ -696,6 +777,7 @@ class DistutilsUnpacked(_Invocations, unittest.TestCase):
         self.run_in_venv(venv, venv, "pip", "install", repodir)
         self.check_in_venv(venv)
 
+
 class SetuptoolsUnpacked(_Invocations, unittest.TestCase):
     def test_install(self):
         unpacked = self.make_setuptools_unpacked()
@@ -704,8 +786,7 @@ class SetuptoolsUnpacked(_Invocations, unittest.TestCase):
         # "setup.py install" doesn't take --no-index or --find-links, so we
         # pre-install the dependency
         self.run_in_venv(venv, venv, "pip", "install", demolib)
-        self.run_in_venv(venv, unpacked,
-                         "python", "setup.py", "install")
+        self.run_in_venv(venv, unpacked, "python", "setup.py", "install")
         self.check_in_venv_withlib(venv)
 
     def test_install_subproject(self):
@@ -715,8 +796,7 @@ class SetuptoolsUnpacked(_Invocations, unittest.TestCase):
         # "setup.py install" doesn't take --no-index or --find-links, so we
         # pre-install the dependency
         self.run_in_venv(venv, venv, "pip", "install", demolib)
-        self.run_in_venv(venv, unpacked,
-                         "python", "setup.py", "install")
+        self.run_in_venv(venv, unpacked, "python", "setup.py", "install")
         self.check_in_venv_withlib(venv)
 
     def test_wheel(self):
@@ -731,10 +811,18 @@ class SetuptoolsUnpacked(_Invocations, unittest.TestCase):
         linkdir = self.make_linkdir()
         wheelname = "demoapp2-2.0-%s-none-any.whl" % pyver_major
         venv = self.make_venv("setuptools-unpacked-pip-wheel")
-        self.run_in_venv(venv, unpacked,
-                         "pip", "wheel", "--wheel-dir", "wheelhouse",
-                         "--no-index", "--find-links", linkdir,
-                         ".")
+        self.run_in_venv(
+            venv,
+            unpacked,
+            "pip",
+            "wheel",
+            "--wheel-dir",
+            "wheelhouse",
+            "--no-index",
+            "--find-links",
+            linkdir,
+            ".",
+        )
         created = os.path.join(unpacked, "wheelhouse", wheelname)
         self.assertTrue(os.path.exists(created), created)
 
@@ -742,31 +830,33 @@ class SetuptoolsUnpacked(_Invocations, unittest.TestCase):
         linkdir = self.make_linkdir()
         repodir = self.make_setuptools_unpacked()
         venv = self.make_venv("setuptools-unpacked-pip-install")
-        self.run_in_venv(venv, repodir, "pip", "install", ".",
-                         "--no-index", "--find-links", linkdir)
+        self.run_in_venv(
+            venv, repodir, "pip", "install", ".", "--no-index", "--find-links", linkdir
+        )
         self.check_in_venv_withlib(venv)
 
     def test_pip_install_subproject(self):
         linkdir = self.make_linkdir()
         unpacked = self.make_setuptools_subproject_unpacked()
         venv = self.make_venv("setuptools-subproject-unpacked-pip-install")
-        self.run_in_venv(venv, unpacked, "pip", "install", ".",
-                         "--no-index", "--find-links", linkdir)
+        self.run_in_venv(
+            venv, unpacked, "pip", "install", ".", "--no-index", "--find-links", linkdir
+        )
         self.check_in_venv_withlib(venv)
 
     def test_pip_install_from_afar(self):
         linkdir = self.make_linkdir()
         repodir = self.make_setuptools_unpacked()
         venv = self.make_venv("setuptools-unpacked-pip-install-from-afar")
-        self.run_in_venv(venv, venv, "pip", "install", repodir,
-                         "--no-index", "--find-links", linkdir)
+        self.run_in_venv(
+            venv, venv, "pip", "install", repodir, "--no-index", "--find-links", linkdir
+        )
         self.check_in_venv_withlib(venv)
 
     def test_extension_wheel_setuptools(self):
         # create an wheel of demoappext-setuptools at 2.0
-        wheelname = self.make_binary_wheelname('demoappext')
-        demoappext_setuptools_wheel = self.subpath("cache", "setuptools",
-                                                   wheelname)
+        wheelname = self.make_binary_wheelname("demoappext")
+        demoappext_setuptools_wheel = self.subpath("cache", "setuptools", wheelname)
         if os.path.exists(demoappext_setuptools_wheel):
             # there are two ways to make this .whl, and we need to exercise
             # both, so don't actually cache the results
@@ -780,8 +870,7 @@ class SetuptoolsUnpacked(_Invocations, unittest.TestCase):
         # build extensions in place. No wheel package
         unpacked = self.make_setuptools_extension_unpacked()
         venv = self.make_venv("setuptools-unpacked-pip-wheel-extension")
-        self.run_in_venv(venv, unpacked,
-                         "python", "setup.py", "build_ext", "-i")
+        self.run_in_venv(venv, unpacked, "python", "setup.py", "build_ext", "-i")
         # No wheel package is created, _version.py should exist in
         # module dir only
         version_file = os.path.join(unpacked, "demo", "_version.py")
@@ -789,9 +878,8 @@ class SetuptoolsUnpacked(_Invocations, unittest.TestCase):
 
     def test_extension_wheel_pip(self):
         # create an wheel of demoappext-setuptools at 2.0 with pip
-        wheelname = self.make_binary_wheelname('demoappext')
-        demoappext_setuptools_wheel = self.subpath("cache", "setuptools",
-                                                   wheelname)
+        wheelname = self.make_binary_wheelname("demoappext")
+        demoappext_setuptools_wheel = self.subpath("cache", "setuptools", wheelname)
         if os.path.exists(demoappext_setuptools_wheel):
             # there are two ways to make this .whl, and we need to exercise
             # both, so don't actually cache the results
@@ -799,13 +887,21 @@ class SetuptoolsUnpacked(_Invocations, unittest.TestCase):
         unpacked = self.make_setuptools_extension_unpacked()
         linkdir = self.make_linkdir()
         venv = self.make_venv("setuptools-unpacked-pip-wheel-extension")
-        self.run_in_venv(venv, unpacked,
-                         "pip", "wheel", "--wheel-dir", "wheelhouse",
-                         "--no-index", "--find-links", linkdir,
-                         ".")
+        self.run_in_venv(
+            venv,
+            unpacked,
+            "pip",
+            "wheel",
+            "--wheel-dir",
+            "wheelhouse",
+            "--no-index",
+            "--find-links",
+            linkdir,
+            ".",
+        )
         created = os.path.join(unpacked, "wheelhouse", wheelname)
         self.assertTrue(os.path.exists(created), created)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/test/run_pyflakes_src.py
+++ b/test/run_pyflakes_src.py
@@ -1,6 +1,7 @@
 import os
 from pyflakes.api import main
 
+
 def get_filenames():
     for dirpath, dirnames, filenames in os.walk("src"):
         if dirpath.endswith("__pycache__"):
@@ -9,11 +10,13 @@ def get_filenames():
             if not rel_fn.endswith(".py"):
                 continue
             fn = os.path.join(dirpath, rel_fn)
-            if fn in [os.path.join("src", "header.py"),
-                      os.path.join("src", "git", "long_header.py"),
-                      ]:
+            if fn in [
+                os.path.join("src", "header.py"),
+                os.path.join("src", "git", "long_header.py"),
+            ]:
                 continue
             print("pyflakes on:", fn)
             yield fn
+
 
 main(args=list(get_filenames()))

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -14,6 +14,7 @@ tag_prefix = v
 parentdir_prefix = petmail-
 """
 
+
 class Parser(unittest.TestCase):
     def parse(self, contents):
         with tempfile.TemporaryDirectory() as root:
@@ -32,12 +33,10 @@ class Parser(unittest.TestCase):
         self.assertEqual(cfg.verbose, None)
 
     def test_empty(self):
-        self.assertRaises(configparser.NoSectionError,
-                          self.parse, "")
+        self.assertRaises(configparser.NoSectionError, self.parse, "")
 
     def test_mostly_empty(self):
-        self.assertRaises(configparser.NoOptionError,
-                          self.parse, "[versioneer]\n")
+        self.assertRaises(configparser.NoOptionError, self.parse, "[versioneer]\n")
 
     def test_minimal(self):
         cfg = self.parse("[versioneer]\nvcs = git\n")
@@ -58,5 +57,5 @@ class Parser(unittest.TestCase):
         self.assertEqual(cfg.tag_prefix, "")
         cfg = self.parse("[versioneer]\nVCS=git\ntag_prefix=''")
         self.assertEqual(cfg.tag_prefix, "")
-        cfg = self.parse("[versioneer]\nVCS=git\ntag_prefix=\"\"")
+        cfg = self.parse('[versioneer]\nVCS=git\ntag_prefix=""')
         self.assertEqual(cfg.tag_prefix, "")

--- a/test/test_file.py
+++ b/test/test_file.py
@@ -1,6 +1,7 @@
 import os, tempfile, unittest
 from versioneer import versions_from_file
 
+
 class Parser(unittest.TestCase):
     def test_lf(self):
         with tempfile.TemporaryDirectory() as root:

--- a/test/test_render.py
+++ b/test/test_render.py
@@ -10,62 +10,69 @@ class Testing_renderer_case_mixin(object):
     and example.
 
     """
+
     def define_pieces(self, closest_tag, distance=0, dirty=False, branch=False):
-        return {"error": '',
-                "closest-tag": closest_tag,
-                "distance": distance,
-                "dirty": dirty,
-                "short": "abc" if distance else '',
-                "long": "abcdefg" if distance else '',
-                "date": "2016-05-31T13:02:11+0200",
-                "branch": "feature" if branch else "master"}
+        return {
+            "error": "",
+            "closest-tag": closest_tag,
+            "distance": distance,
+            "dirty": dirty,
+            "short": "abc" if distance else "",
+            "long": "abcdefg" if distance else "",
+            "date": "2016-05-31T13:02:11+0200",
+            "branch": "feature" if branch else "master",
+        }
 
     def assert_rendered(self, pieces, test_case_name):
-        version = render(pieces, self.style)['version']
+        version = render(pieces, self.style)["version"]
         expected = self.expected[test_case_name]
-        msg = ('Versions differ for {0} style with "{1}" case: expected {2}, '
-               'got {3}'.format(self.style, test_case_name, expected, version))
+        msg = (
+            'Versions differ for {0} style with "{1}" case: expected {2}, '
+            "got {3}".format(self.style, test_case_name, expected, version)
+        )
         self.assertEqual(version, expected, msg)
 
     # Naming structure:
     # test_(un)tagged_<n>_commits_(clean|dirty)
     def test_tagged_0_commits_clean(self):
-        self.assert_rendered(self.define_pieces('v1.2.3'),
-                             'tagged_0_commits_clean')
+        self.assert_rendered(self.define_pieces("v1.2.3"), "tagged_0_commits_clean")
 
     def test_tagged_1_commits_clean(self):
-        self.assert_rendered(self.define_pieces('v1.2.3', distance=1),
-                             'tagged_1_commits_clean')
+        self.assert_rendered(
+            self.define_pieces("v1.2.3", distance=1), "tagged_1_commits_clean"
+        )
 
     def test_tagged_0_commits_dirty(self):
-        self.assert_rendered(self.define_pieces('v1.2.3', dirty=True),
-                             'tagged_0_commits_dirty')
+        self.assert_rendered(
+            self.define_pieces("v1.2.3", dirty=True), "tagged_0_commits_dirty"
+        )
 
     def test_tagged_1_commits_dirty(self):
-        self.assert_rendered(self.define_pieces('v1.2.3', distance=1,
-                                                dirty=True),
-                             'tagged_1_commits_dirty')
+        self.assert_rendered(
+            self.define_pieces("v1.2.3", distance=1, dirty=True),
+            "tagged_1_commits_dirty",
+        )
 
     def test_untagged_0_commits_clean(self):
-        self.assert_rendered(self.define_pieces(None),
-                             'untagged_0_commits_clean')
+        self.assert_rendered(self.define_pieces(None), "untagged_0_commits_clean")
 
     def test_untagged_1_commits_clean(self):
-        self.assert_rendered(self.define_pieces(None, distance=1),
-                             'untagged_1_commits_clean')
+        self.assert_rendered(
+            self.define_pieces(None, distance=1), "untagged_1_commits_clean"
+        )
 
     def test_untagged_0_commits_dirty(self):
-        self.assert_rendered(self.define_pieces(None, dirty=True),
-                             'untagged_0_commits_dirty')
+        self.assert_rendered(
+            self.define_pieces(None, dirty=True), "untagged_0_commits_dirty"
+        )
 
     def test_untagged_1_commits_dirty(self):
-        self.assert_rendered(self.define_pieces(None, distance=1,
-                                                dirty=True),
-                             'untagged_1_commits_dirty')
+        self.assert_rendered(
+            self.define_pieces(None, distance=1, dirty=True), "untagged_1_commits_dirty"
+        )
 
     def test_error_getting_parts(self):
-        self.assert_rendered({'error': 'Not a git repo'},
-                             'error_getting_parts')
+        self.assert_rendered({"error": "Not a git repo"}, "error_getting_parts")
 
 
 class Testing_branch_renderer_case_mixin(Testing_renderer_case_mixin):
@@ -78,40 +85,50 @@ class Testing_branch_renderer_case_mixin(Testing_renderer_case_mixin):
     # Naming structure:
     # test_branch_(un)tagged_<n>_commits_(clean|dirty)
     def test_branch_tagged_0_commits_clean(self):
-        self.assert_rendered(self.define_pieces('v1.2.3', branch=True),
-                             'branch_tagged_0_commits_clean')
+        self.assert_rendered(
+            self.define_pieces("v1.2.3", branch=True), "branch_tagged_0_commits_clean"
+        )
 
     def test_branch_tagged_1_commits_clean(self):
-        self.assert_rendered(self.define_pieces('v1.2.3', branch=True,
-                                                distance=1),
-                             'branch_tagged_1_commits_clean')
+        self.assert_rendered(
+            self.define_pieces("v1.2.3", branch=True, distance=1),
+            "branch_tagged_1_commits_clean",
+        )
 
     def test_branch_tagged_0_commits_dirty(self):
-        self.assert_rendered(self.define_pieces('v1.2.3', branch=True,
-                                                dirty=True),
-                             'branch_tagged_0_commits_dirty')
+        self.assert_rendered(
+            self.define_pieces("v1.2.3", branch=True, dirty=True),
+            "branch_tagged_0_commits_dirty",
+        )
 
     def test_branch_tagged_1_commits_dirty(self):
-        self.assert_rendered(self.define_pieces('v1.2.3', branch=True,
-                                                distance=1, dirty=True),
-                             'branch_tagged_1_commits_dirty')
+        self.assert_rendered(
+            self.define_pieces("v1.2.3", branch=True, distance=1, dirty=True),
+            "branch_tagged_1_commits_dirty",
+        )
 
     def test_branch_untagged_0_commits_clean(self):
-        self.assert_rendered(self.define_pieces(None, branch=True),
-                             'branch_untagged_0_commits_clean')
+        self.assert_rendered(
+            self.define_pieces(None, branch=True), "branch_untagged_0_commits_clean"
+        )
 
     def test_branch_untagged_1_commits_clean(self):
-        self.assert_rendered(self.define_pieces(None, branch=True, distance=1),
-                             'branch_untagged_1_commits_clean')
+        self.assert_rendered(
+            self.define_pieces(None, branch=True, distance=1),
+            "branch_untagged_1_commits_clean",
+        )
 
     def test_branch_untagged_0_commits_dirty(self):
-        self.assert_rendered(self.define_pieces(None, branch=True, dirty=True),
-                             'branch_untagged_0_commits_dirty')
+        self.assert_rendered(
+            self.define_pieces(None, branch=True, dirty=True),
+            "branch_untagged_0_commits_dirty",
+        )
 
     def test_branch_untagged_1_commits_dirty(self):
-        self.assert_rendered(self.define_pieces(None, branch=True, distance=1,
-                                                dirty=True),
-                             'branch_untagged_1_commits_dirty')
+        self.assert_rendered(
+            self.define_pieces(None, branch=True, distance=1, dirty=True),
+            "branch_untagged_1_commits_dirty",
+        )
 
 
 class Testing_post_renderer_case_mixin(Testing_renderer_case_mixin):
@@ -124,163 +141,178 @@ class Testing_post_renderer_case_mixin(Testing_renderer_case_mixin):
     # Naming structure:
     # test_(un)tagged_post<n>_<n>_commits_(clean|dirty)
     def test_tagged_post_0_commits_clean(self):
-        self.assert_rendered(self.define_pieces('v1.2.3.post'),
-                             'tagged_post_0_commits_clean')
-    
+        self.assert_rendered(
+            self.define_pieces("v1.2.3.post"), "tagged_post_0_commits_clean"
+        )
+
     def test_tagged_post1_0_commits_clean(self):
-        self.assert_rendered(self.define_pieces('v1.2.3.post1'),
-                             'tagged_post1_0_commits_clean')
-    
+        self.assert_rendered(
+            self.define_pieces("v1.2.3.post1"), "tagged_post1_0_commits_clean"
+        )
+
     def test_tagged_post_1_commits_clean(self):
-        self.assert_rendered(self.define_pieces('v1.2.3.post', distance=1),
-                             'tagged_post_1_commits_clean')
-    
+        self.assert_rendered(
+            self.define_pieces("v1.2.3.post", distance=1), "tagged_post_1_commits_clean"
+        )
+
     def test_tagged_post1_1_commits_clean(self):
-        self.assert_rendered(self.define_pieces('v1.2.3.post1', distance=1),
-                             'tagged_post1_1_commits_clean')
+        self.assert_rendered(
+            self.define_pieces("v1.2.3.post1", distance=1),
+            "tagged_post1_1_commits_clean",
+        )
 
     def test_tagged_post_0_commits_dirty(self):
-        self.assert_rendered(self.define_pieces('v1.2.3.post', dirty=True),
-                             'tagged_post_0_commits_dirty')
-    
+        self.assert_rendered(
+            self.define_pieces("v1.2.3.post", dirty=True), "tagged_post_0_commits_dirty"
+        )
+
     def test_tagged_post1_0_commits_dirty(self):
-        self.assert_rendered(self.define_pieces('v1.2.3.post1', dirty=True),
-                             'tagged_post1_0_commits_dirty')
-    
+        self.assert_rendered(
+            self.define_pieces("v1.2.3.post1", dirty=True),
+            "tagged_post1_0_commits_dirty",
+        )
+
     def test_tagged_post_1_commits_dirty(self):
-        self.assert_rendered(self.define_pieces('v1.2.3.post', distance=1,
-                                                dirty=True),
-                             'tagged_post_1_commits_dirty')
-    
+        self.assert_rendered(
+            self.define_pieces("v1.2.3.post", distance=1, dirty=True),
+            "tagged_post_1_commits_dirty",
+        )
+
     def test_tagged_post1_1_commits_dirty(self):
-        self.assert_rendered(self.define_pieces('v1.2.3.post1', distance=1,
-                                                dirty=True),
-                             'tagged_post1_1_commits_dirty')
+        self.assert_rendered(
+            self.define_pieces("v1.2.3.post1", distance=1, dirty=True),
+            "tagged_post1_1_commits_dirty",
+        )
 
 
 class Test_pep440(unittest.TestCase, Testing_renderer_case_mixin):
-    style = 'pep440'
-    expected = {'tagged_0_commits_clean': 'v1.2.3',
-                'tagged_0_commits_dirty': 'v1.2.3+0.g.dirty',
-                'tagged_1_commits_clean': 'v1.2.3+1.gabc',
-                'tagged_1_commits_dirty': 'v1.2.3+1.gabc.dirty',
-                'untagged_0_commits_clean': '0+untagged.0.g',
-                'untagged_0_commits_dirty': '0+untagged.0.g.dirty',
-                'untagged_1_commits_clean': '0+untagged.1.gabc',
-                'untagged_1_commits_dirty': '0+untagged.1.gabc.dirty',
-                'error_getting_parts': 'unknown'
-                }
+    style = "pep440"
+    expected = {
+        "tagged_0_commits_clean": "v1.2.3",
+        "tagged_0_commits_dirty": "v1.2.3+0.g.dirty",
+        "tagged_1_commits_clean": "v1.2.3+1.gabc",
+        "tagged_1_commits_dirty": "v1.2.3+1.gabc.dirty",
+        "untagged_0_commits_clean": "0+untagged.0.g",
+        "untagged_0_commits_dirty": "0+untagged.0.g.dirty",
+        "untagged_1_commits_clean": "0+untagged.1.gabc",
+        "untagged_1_commits_dirty": "0+untagged.1.gabc.dirty",
+        "error_getting_parts": "unknown",
+    }
 
 
-class Test_pep440_branch(unittest.TestCase,
-                         Testing_branch_renderer_case_mixin):
-    style = 'pep440-branch'
-    expected = {'tagged_0_commits_clean': 'v1.2.3',
-                'tagged_0_commits_dirty': 'v1.2.3+0.g.dirty',
-                'tagged_1_commits_clean': 'v1.2.3+1.gabc',
-                'tagged_1_commits_dirty': 'v1.2.3+1.gabc.dirty',
-                'untagged_0_commits_clean': '0+untagged.0.g',
-                'untagged_0_commits_dirty': '0+untagged.0.g.dirty',
-                'untagged_1_commits_clean': '0+untagged.1.gabc',
-                'untagged_1_commits_dirty': '0+untagged.1.gabc.dirty',
-                'branch_tagged_0_commits_clean': 'v1.2.3',
-                'branch_tagged_0_commits_dirty': 'v1.2.3.dev0+0.g.dirty',
-                'branch_tagged_1_commits_clean': 'v1.2.3.dev0+1.gabc',
-                'branch_tagged_1_commits_dirty': 'v1.2.3.dev0+1.gabc.dirty',
-                'branch_untagged_0_commits_clean': '0.dev0+untagged.0.g',
-                'branch_untagged_0_commits_dirty': '0.dev0+untagged.0.g.dirty',
-                'branch_untagged_1_commits_clean': '0.dev0+untagged.1.gabc',
-                'branch_untagged_1_commits_dirty': '0.dev0+untagged.1.gabc.dirty',
-                'error_getting_parts': 'unknown'
-                }
+class Test_pep440_branch(unittest.TestCase, Testing_branch_renderer_case_mixin):
+    style = "pep440-branch"
+    expected = {
+        "tagged_0_commits_clean": "v1.2.3",
+        "tagged_0_commits_dirty": "v1.2.3+0.g.dirty",
+        "tagged_1_commits_clean": "v1.2.3+1.gabc",
+        "tagged_1_commits_dirty": "v1.2.3+1.gabc.dirty",
+        "untagged_0_commits_clean": "0+untagged.0.g",
+        "untagged_0_commits_dirty": "0+untagged.0.g.dirty",
+        "untagged_1_commits_clean": "0+untagged.1.gabc",
+        "untagged_1_commits_dirty": "0+untagged.1.gabc.dirty",
+        "branch_tagged_0_commits_clean": "v1.2.3",
+        "branch_tagged_0_commits_dirty": "v1.2.3.dev0+0.g.dirty",
+        "branch_tagged_1_commits_clean": "v1.2.3.dev0+1.gabc",
+        "branch_tagged_1_commits_dirty": "v1.2.3.dev0+1.gabc.dirty",
+        "branch_untagged_0_commits_clean": "0.dev0+untagged.0.g",
+        "branch_untagged_0_commits_dirty": "0.dev0+untagged.0.g.dirty",
+        "branch_untagged_1_commits_clean": "0.dev0+untagged.1.gabc",
+        "branch_untagged_1_commits_dirty": "0.dev0+untagged.1.gabc.dirty",
+        "error_getting_parts": "unknown",
+    }
 
 
 class Test_pep440_old(unittest.TestCase, Testing_renderer_case_mixin):
-    style = 'pep440-old'
-    expected = {'tagged_0_commits_clean': 'v1.2.3',
-                'tagged_0_commits_dirty': 'v1.2.3.post0.dev0',
-                'tagged_1_commits_clean': 'v1.2.3.post1',
-                'tagged_1_commits_dirty': 'v1.2.3.post1.dev0',
-                'untagged_0_commits_clean': '0.post0',
-                'untagged_0_commits_dirty': '0.post0.dev0',
-                'untagged_1_commits_clean': '0.post1',
-                'untagged_1_commits_dirty': '0.post1.dev0',
-                'error_getting_parts': 'unknown'
-                }
+    style = "pep440-old"
+    expected = {
+        "tagged_0_commits_clean": "v1.2.3",
+        "tagged_0_commits_dirty": "v1.2.3.post0.dev0",
+        "tagged_1_commits_clean": "v1.2.3.post1",
+        "tagged_1_commits_dirty": "v1.2.3.post1.dev0",
+        "untagged_0_commits_clean": "0.post0",
+        "untagged_0_commits_dirty": "0.post0.dev0",
+        "untagged_1_commits_clean": "0.post1",
+        "untagged_1_commits_dirty": "0.post1.dev0",
+        "error_getting_parts": "unknown",
+    }
 
 
 class Test_pep440_post(unittest.TestCase, Testing_renderer_case_mixin):
-    style = 'pep440-post'
-    expected = {'tagged_0_commits_clean': 'v1.2.3',
-                'tagged_0_commits_dirty': 'v1.2.3.post0.dev0+g',
-                'tagged_1_commits_clean': 'v1.2.3.post1+gabc',
-                'tagged_1_commits_dirty': 'v1.2.3.post1.dev0+gabc',
-                'untagged_0_commits_clean': '0.post0+g',
-                'untagged_0_commits_dirty': '0.post0.dev0+g',
-                'untagged_1_commits_clean': '0.post1+gabc',
-                'untagged_1_commits_dirty': '0.post1.dev0+gabc',
-                'error_getting_parts': 'unknown'
-                }
+    style = "pep440-post"
+    expected = {
+        "tagged_0_commits_clean": "v1.2.3",
+        "tagged_0_commits_dirty": "v1.2.3.post0.dev0+g",
+        "tagged_1_commits_clean": "v1.2.3.post1+gabc",
+        "tagged_1_commits_dirty": "v1.2.3.post1.dev0+gabc",
+        "untagged_0_commits_clean": "0.post0+g",
+        "untagged_0_commits_dirty": "0.post0.dev0+g",
+        "untagged_1_commits_clean": "0.post1+gabc",
+        "untagged_1_commits_dirty": "0.post1.dev0+gabc",
+        "error_getting_parts": "unknown",
+    }
 
 
-class Test_pep440_post_branch(unittest.TestCase,
-                              Testing_branch_renderer_case_mixin):
-    style = 'pep440-post-branch'
-    expected = {'tagged_0_commits_clean': 'v1.2.3',
-                'tagged_0_commits_dirty': 'v1.2.3.post0+g.dirty',
-                'tagged_1_commits_clean': 'v1.2.3.post1+gabc',
-                'tagged_1_commits_dirty': 'v1.2.3.post1+gabc.dirty',
-                'untagged_0_commits_clean': '0.post0+g',
-                'untagged_0_commits_dirty': '0.post0+g.dirty',
-                'untagged_1_commits_clean': '0.post1+gabc',
-                'untagged_1_commits_dirty': '0.post1+gabc.dirty',
-                'branch_tagged_0_commits_clean': 'v1.2.3',
-                'branch_tagged_0_commits_dirty': 'v1.2.3.post0.dev0+g.dirty',
-                'branch_tagged_1_commits_clean': 'v1.2.3.post1.dev0+gabc',
-                'branch_tagged_1_commits_dirty': 'v1.2.3.post1.dev0+gabc.dirty',
-                'branch_untagged_0_commits_clean': '0.post0.dev0+g',
-                'branch_untagged_0_commits_dirty': '0.post0.dev0+g.dirty',
-                'branch_untagged_1_commits_clean': '0.post1.dev0+gabc',
-                'branch_untagged_1_commits_dirty': '0.post1.dev0+gabc.dirty',
-                'error_getting_parts': 'unknown'
-                }
+class Test_pep440_post_branch(unittest.TestCase, Testing_branch_renderer_case_mixin):
+    style = "pep440-post-branch"
+    expected = {
+        "tagged_0_commits_clean": "v1.2.3",
+        "tagged_0_commits_dirty": "v1.2.3.post0+g.dirty",
+        "tagged_1_commits_clean": "v1.2.3.post1+gabc",
+        "tagged_1_commits_dirty": "v1.2.3.post1+gabc.dirty",
+        "untagged_0_commits_clean": "0.post0+g",
+        "untagged_0_commits_dirty": "0.post0+g.dirty",
+        "untagged_1_commits_clean": "0.post1+gabc",
+        "untagged_1_commits_dirty": "0.post1+gabc.dirty",
+        "branch_tagged_0_commits_clean": "v1.2.3",
+        "branch_tagged_0_commits_dirty": "v1.2.3.post0.dev0+g.dirty",
+        "branch_tagged_1_commits_clean": "v1.2.3.post1.dev0+gabc",
+        "branch_tagged_1_commits_dirty": "v1.2.3.post1.dev0+gabc.dirty",
+        "branch_untagged_0_commits_clean": "0.post0.dev0+g",
+        "branch_untagged_0_commits_dirty": "0.post0.dev0+g.dirty",
+        "branch_untagged_1_commits_clean": "0.post1.dev0+gabc",
+        "branch_untagged_1_commits_dirty": "0.post1.dev0+gabc.dirty",
+        "error_getting_parts": "unknown",
+    }
 
 
 class Test_pep440_pre(unittest.TestCase, Testing_post_renderer_case_mixin):
-    style = 'pep440-pre'
-    expected = {'tagged_0_commits_clean': 'v1.2.3',
-                'tagged_0_commits_dirty': 'v1.2.3',
-                'tagged_1_commits_clean': 'v1.2.3.post0.dev1',
-                'tagged_1_commits_dirty': 'v1.2.3.post0.dev1',
-                'untagged_0_commits_clean': '0.post0.dev0',
-                'untagged_0_commits_dirty': '0.post0.dev0',
-                'untagged_1_commits_clean': '0.post0.dev1',
-                'untagged_1_commits_dirty': '0.post0.dev1',
-                'tagged_post_0_commits_clean': 'v1.2.3.post',
-                'tagged_post1_0_commits_clean': 'v1.2.3.post1',
-                'tagged_post_1_commits_clean': 'v1.2.3.post1.dev1',
-                'tagged_post1_1_commits_clean': 'v1.2.3.post2.dev1',
-                'tagged_post_0_commits_dirty': 'v1.2.3.post',
-                'tagged_post1_0_commits_dirty': 'v1.2.3.post1',
-                'tagged_post_1_commits_dirty': 'v1.2.3.post1.dev1',
-                'tagged_post1_1_commits_dirty': 'v1.2.3.post2.dev1',
-                'error_getting_parts': 'unknown'
-                }
+    style = "pep440-pre"
+    expected = {
+        "tagged_0_commits_clean": "v1.2.3",
+        "tagged_0_commits_dirty": "v1.2.3",
+        "tagged_1_commits_clean": "v1.2.3.post0.dev1",
+        "tagged_1_commits_dirty": "v1.2.3.post0.dev1",
+        "untagged_0_commits_clean": "0.post0.dev0",
+        "untagged_0_commits_dirty": "0.post0.dev0",
+        "untagged_1_commits_clean": "0.post0.dev1",
+        "untagged_1_commits_dirty": "0.post0.dev1",
+        "tagged_post_0_commits_clean": "v1.2.3.post",
+        "tagged_post1_0_commits_clean": "v1.2.3.post1",
+        "tagged_post_1_commits_clean": "v1.2.3.post1.dev1",
+        "tagged_post1_1_commits_clean": "v1.2.3.post2.dev1",
+        "tagged_post_0_commits_dirty": "v1.2.3.post",
+        "tagged_post1_0_commits_dirty": "v1.2.3.post1",
+        "tagged_post_1_commits_dirty": "v1.2.3.post1.dev1",
+        "tagged_post1_1_commits_dirty": "v1.2.3.post2.dev1",
+        "error_getting_parts": "unknown",
+    }
 
 
 class Test_git_describe(unittest.TestCase, Testing_renderer_case_mixin):
-    style = 'git-describe'
-    expected = {'tagged_0_commits_clean': 'v1.2.3',
-                'tagged_0_commits_dirty': 'v1.2.3-dirty',
-                'tagged_1_commits_clean': 'v1.2.3-1-gabc',
-                'tagged_1_commits_dirty': 'v1.2.3-1-gabc-dirty',
-                'untagged_0_commits_clean': '',
-                'untagged_0_commits_dirty': '-dirty',
-                'untagged_1_commits_clean': 'abc',
-                'untagged_1_commits_dirty': 'abc-dirty',
-                'error_getting_parts': 'unknown'
-                }
+    style = "git-describe"
+    expected = {
+        "tagged_0_commits_clean": "v1.2.3",
+        "tagged_0_commits_dirty": "v1.2.3-dirty",
+        "tagged_1_commits_clean": "v1.2.3-1-gabc",
+        "tagged_1_commits_dirty": "v1.2.3-1-gabc-dirty",
+        "untagged_0_commits_clean": "",
+        "untagged_0_commits_dirty": "-dirty",
+        "untagged_1_commits_clean": "abc",
+        "untagged_1_commits_dirty": "abc-dirty",
+        "error_getting_parts": "unknown",
+    }
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
When updating python-versioneer on Geopandas our linters when off because [black](https://github.com/psf/black) formatting wasn't followed. So I reformatted the whole repository with black 21.11b1.