### PR TITLE
FIX: Unset GIT_DIR environment variable while retrieving version information from git

### DIFF
--- a/src/get_versions.py
+++ b/src/get_versions.py
@@ -1,4 +1,5 @@
 import os, sys # --STRIP DURING BUILD
+from unittest import mock # --STRIP DURING BUILD
 def get_root(): pass # --STRIP DURING BUILD
 def get_config_from_root(): pass # --STRIP DURING BUILD
 def versions_from_file(): pass # --STRIP DURING BUILD
@@ -61,14 +62,17 @@ def get_versions(verbose=False):
 
     from_vcs_f = handlers.get("pieces_from_vcs")
     if from_vcs_f:
-        try:
-            pieces = from_vcs_f(cfg.tag_prefix, root, verbose)
-            ver = render(pieces, cfg.style)
-            if verbose:
-                print("got version from VCS %s" % ver)
-            return ver
-        except NotThisMethod:
-            pass
+        # Patch os.environ to allow handlers to modify their
+        # environment without affecting later subprocesses
+        with mock.patch.dict(os.environ):
+            try:
+                pieces = from_vcs_f(cfg.tag_prefix, root, verbose)
+                ver = render(pieces, cfg.style)
+                if verbose:
+                    print("got version from VCS %s" % ver)
+                return ver
+            except NotThisMethod:
+                pass
 
     try:
         if cfg.parentdir_prefix:

--- a/src/get_versions.py
+++ b/src/get_versions.py
@@ -1,5 +1,4 @@
 import os, sys # --STRIP DURING BUILD
-from unittest import mock # --STRIP DURING BUILD
 def get_root(): pass # --STRIP DURING BUILD
 def get_config_from_root(): pass # --STRIP DURING BUILD
 def versions_from_file(): pass # --STRIP DURING BUILD
@@ -62,17 +61,14 @@ def get_versions(verbose=False):
 
     from_vcs_f = handlers.get("pieces_from_vcs")
     if from_vcs_f:
-        # Patch os.environ to allow handlers to modify their
-        # environment without affecting later subprocesses
-        with mock.patch.dict(os.environ):
-            try:
-                pieces = from_vcs_f(cfg.tag_prefix, root, verbose)
-                ver = render(pieces, cfg.style)
-                if verbose:
-                    print("got version from VCS %s" % ver)
-                return ver
-            except NotThisMethod:
-                pass
+        try:
+            pieces = from_vcs_f(cfg.tag_prefix, root, verbose)
+            ver = render(pieces, cfg.style)
+            if verbose:
+                print("got version from VCS %s" % ver)
+            return ver
+        except NotThisMethod:
+            pass
 
     try:
         if cfg.parentdir_prefix:

--- a/src/git/from_vcs.py
+++ b/src/git/from_vcs.py
@@ -1,6 +1,7 @@
 import sys  # --STRIP DURING BUILD
 import re  # --STRIP DURING BUILD
 import os  # --STRIP DURING BUILD
+import functools  # --STRIP DURING BUILD
   # --STRIP DURING BUILD
   # --STRIP DURING BUILD
 def register_vcs_handler(*args):  # --STRIP DURING BUILD
@@ -21,9 +22,6 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, runner=run_command):
     This only gets called if the git-archive 'subst' keywords were *not*
     expanded, and _version.py hasn't already been rewritten with a short
     version string, meaning we're inside a checked out source tree.
-
-    This function modifies the environment, so a caller that needs to
-    preserve the environment should save/restore around the call.
     """
     GITS = ["git"]
     if sys.platform == "win32":
@@ -32,7 +30,9 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, runner=run_command):
     # GIT_DIR can interfere with correct operation of Versioneer.
     # It may be intended to be passed to the Versioneer-versioned project,
     # but that should not change where we get our version from.
-    os.environ.pop("GIT_DIR", None)
+    env = os.environ.copy()
+    env.pop("GIT_DIR", None)
+    runner = functools.partial(runner, env=env)
 
     _, rc = runner(GITS, ["rev-parse", "--git-dir"], cwd=root,
                    hide_stderr=True)

--- a/src/git/from_vcs.py
+++ b/src/git/from_vcs.py
@@ -1,5 +1,6 @@
 import sys  # --STRIP DURING BUILD
 import re  # --STRIP DURING BUILD
+import os  # --STRIP DURING BUILD
   # --STRIP DURING BUILD
   # --STRIP DURING BUILD
 def register_vcs_handler(*args):  # --STRIP DURING BUILD
@@ -20,10 +21,18 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, runner=run_command):
     This only gets called if the git-archive 'subst' keywords were *not*
     expanded, and _version.py hasn't already been rewritten with a short
     version string, meaning we're inside a checked out source tree.
+
+    This function modifies the environment, so a caller that needs to
+    preserve the environment should save/restore around the call.
     """
     GITS = ["git"]
     if sys.platform == "win32":
         GITS = ["git.cmd", "git.exe"]
+
+    # GIT_DIR can interfere with correct operation of Versioneer.
+    # It may be intended to be passed to the Versioneer-versioned project,
+    # but that should not change where we get our version from.
+    os.environ.pop("GIT_DIR", None)
 
     _, rc = runner(GITS, ["rev-parse", "--git-dir"], cwd=root,
                    hide_stderr=True)

--- a/src/git/long_header.py
+++ b/src/git/long_header.py
@@ -15,6 +15,7 @@ import re
 import subprocess
 import sys
 from typing import Callable, Dict
+import functools
 
 
 def get_keywords():

--- a/src/header.py
+++ b/src/header.py
@@ -19,6 +19,7 @@ import re
 import subprocess
 import sys
 from typing import Callable, Dict
+from unittest import mock
 
 
 class VersioneerConfig:

--- a/src/header.py
+++ b/src/header.py
@@ -19,7 +19,7 @@ import re
 import subprocess
 import sys
 from typing import Callable, Dict
-from unittest import mock
+import functools
 
 
 class VersioneerConfig:

--- a/test/git/test_git.py
+++ b/test/git/test_git.py
@@ -26,7 +26,8 @@ class ParseGitDescribe(unittest.TestCase):
     def test_pieces(self):
         def pv(git_describe, do_error=False,
                expect_pieces=False, branch_name="master"):
-            def fake_run_command(exes, args, cwd=None, hide_stderr=None, env=None):
+            def fake_run_command(commands, args, cwd=None, verbose=False,
+                                 hide_stderr=False, env=None):
                 if args[0] == "describe":
                     if do_error == "describe":
                         return None, 0

--- a/test/git/test_git.py
+++ b/test/git/test_git.py
@@ -26,7 +26,7 @@ class ParseGitDescribe(unittest.TestCase):
     def test_pieces(self):
         def pv(git_describe, do_error=False,
                expect_pieces=False, branch_name="master"):
-            def fake_run_command(exes, args, cwd=None, hide_stderr=None):
+            def fake_run_command(exes, args, cwd=None, hide_stderr=None, env=None):
                 if args[0] == "describe":
                     if do_error == "describe":
                         return None, 0


### PR DESCRIPTION
Closes #279.

~~Unclear whether there should be a config variable to allow for different `.git` locations. May not be worth the complexity to cover if the edge case is never actually hit.~~