### PR TITLE
Fix broken tag prefix on Windows and add CI

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest']
-        python-version: [3.6, 3.7, 3.8, 3.9, 'pypy-3.7']
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10', 'pypy-3.7']
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -38,3 +38,11 @@ jobs:
         run: tox
         env:
           PLATFORM: ${{ matrix.os }}
+      - name: Test Git (cmd)
+        run: python test/git/test_git.py -v
+        shell: cmd
+        if: ${{ matrix.os == 'windows-latest' }}
+      - name: Test Git (Powershell)
+        run: python test/git/test_git.py -v
+        shell: pwsh
+        if: ${{ matrix.os == 'windows-latest' }}

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -12,18 +12,28 @@ on:
   schedule:
     - cron: '0 0 * * MON'
 
-defaults:
-  run:
-    shell: bash
-
 jobs:
   stable:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ['ubuntu-latest', 'windows-latest']
+        os: ['ubuntu-latest']
         python-version: [3.6, 3.7, 3.8, 3.9, '3.10', 'pypy-3.7']
+        shell: ['bash']
+        include:
+          - os: 'windows-2019'
+            python-version: '3.10'
+            shell: 'bash'
+          - os: 'windows-2019'
+            python-version: '3.10'
+            shell: 'pwsh'
+          - os: 'windows-2019'
+            python-version: '3.10'
+            shell: 'cmd'
 
+    defaults:
+      run:
+        shell: ${{ matrix.shell }}
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -40,11 +50,3 @@ jobs:
         run: tox
         env:
           PLATFORM: ${{ matrix.os }}
-      - name: Test Git (cmd)
-        run: python test/git/test_git.py -v
-        shell: cmd
-        if: ${{ matrix.os == 'windows-latest' }}
-      - name: Test Git (Powershell)
-        run: python test/git/test_git.py -v
-        shell: pwsh
-        if: ${{ matrix.os == 'windows-latest' }}

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The Versioneer
 * https://github.com/python-versioneer/python-versioneer
 * Brian Warner
 * License: Public Domain
-* Compatible with: Python 3.6, 3.7, 3.8, 3.9 and pypy3
+* Compatible with: Python 3.6, 3.7, 3.8, 3.9, 3.10 and pypy3
 * [![Latest Version][pypi-image]][pypi-url]
 * [![Build Status][travis-image]][travis-url]
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools.dist import Distribution as _Distribution
 LONG = Path.read_text(Path(__file__).parent / "README.md")
 
 # as nice as it'd be to versioneer ourselves, that sounds messy.
-VERSION = "0.21"
+VERSION = "0.22.dev0"
 
 
 def ver(s):

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools.dist import Distribution as _Distribution
 LONG = Path.read_text(Path(__file__).parent / "README.md")
 
 # as nice as it'd be to versioneer ourselves, that sounds messy.
-VERSION = "0.21.dev0"
+VERSION = "0.21"
 
 
 def ver(s):

--- a/src/git/from_vcs.py
+++ b/src/git/from_vcs.py
@@ -22,10 +22,6 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, runner=run_command):
     version string, meaning we're inside a checked out source tree.
     """
     GITS = ["git"]
-    TAG_PREFIX_REGEX = "*"
-    MATCH_ARGS = ["--match", "%s%s" % (tag_prefix, TAG_PREFIX_REGEX)] \
-        if tag_prefix else []
-
     if sys.platform == "win32":
         GITS = ["git.cmd", "git.exe"]
 
@@ -36,10 +32,12 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, runner=run_command):
             print("Directory %s not under git control" % root)
         raise NotThisMethod("'git rev-parse --git-dir' returned error")
 
+    MATCH_ARGS = ["--match", "%s*" % tag_prefix] if tag_prefix else []
+
     # if there is a tag matching tag_prefix, this yields TAG-NUM-gHEX[-dirty]
     # if there isn't one, this yields HEX[-dirty] (no NUM)
     describe_out, rc = runner(GITS, ["describe", "--tags", "--dirty",
-                                     "--always", "--long"] + MATCH_ARGS,
+                                     "--always", "--long", *MATCH_ARGS],
                               cwd=root)
     # --long was added in git-1.5.5
     if describe_out is None:

--- a/src/git/from_vcs.py
+++ b/src/git/from_vcs.py
@@ -25,7 +25,7 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, runner=run_command):
     TAG_PREFIX_REGEX = "*"
     MATCH_ARGS = ["--match", "%s%s" % (tag_prefix, TAG_PREFIX_REGEX)] \
         if tag_prefix else []
-    
+
     if sys.platform == "win32":
         GITS = ["git.cmd", "git.exe"]
 

--- a/src/git/from_vcs.py
+++ b/src/git/from_vcs.py
@@ -23,9 +23,11 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, runner=run_command):
     """
     GITS = ["git"]
     TAG_PREFIX_REGEX = "*"
+    MATCH_ARGS = ["--match", "%s%s" % (tag_prefix, TAG_PREFIX_REGEX)] \
+        if tag_prefix else []
+    
     if sys.platform == "win32":
         GITS = ["git.cmd", "git.exe"]
-        TAG_PREFIX_REGEX = r"\*"
 
     _, rc = runner(GITS, ["rev-parse", "--git-dir"], cwd=root,
                    hide_stderr=True)
@@ -37,9 +39,7 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, runner=run_command):
     # if there is a tag matching tag_prefix, this yields TAG-NUM-gHEX[-dirty]
     # if there isn't one, this yields HEX[-dirty] (no NUM)
     describe_out, rc = runner(GITS, ["describe", "--tags", "--dirty",
-                                     "--always", "--long",
-                                     "--match",
-                                     "%s%s" % (tag_prefix, TAG_PREFIX_REGEX)],
+                                     "--always", "--long"] + MATCH_ARGS,
                               cwd=root)
     # --long was added in git-1.5.5
     if describe_out is None:

--- a/test/git/test_git.py
+++ b/test/git/test_git.py
@@ -412,7 +412,7 @@ class Repo(common.Common, unittest.TestCase):
         # isn't the child of the versioneer repo's .git directory, since that
         # will confuse the tests that check what happens when there is no
         # .git parent. So if you change this to use a fixed directory (say,
-        # when debugging problems), use /tmp/_test rather than ./_test .        
+        # when debugging problems), use /tmp/_test rather than ./_test .
         self.testdir = tempfile.mkdtemp()
         if VERBOSE: print("testdir: %s" % (self.testdir,))
         if os.path.exists(self.testdir):
@@ -436,13 +436,13 @@ class Repo(common.Common, unittest.TestCase):
         with open(setup_cfg_fn, "r") as f:
             setup_cfg = f.read()
         setup_cfg = setup_cfg.replace("@VCS@", "git")
-        
+
         tag_prefix_regex = "tag_prefix = (.*)"
         if tag_prefix is None:
             tag_prefix = re.search(tag_prefix_regex, setup_cfg).group(1)
         else:
             setup_cfg = re.sub(tag_prefix_regex, f"tag_prefix = {tag_prefix}", setup_cfg)
-        
+
         with open(setup_cfg_fn, "w") as f:
             f.write(setup_cfg)
         shutil.copyfile("versioneer.py", self.project_file("versioneer.py"))

--- a/test/git/test_invocations.py
+++ b/test/git/test_invocations.py
@@ -1,4 +1,4 @@
-import os, sys, shutil, unittest, tempfile, tarfile, virtualenv, warnings
+import os, sys, shutil, unittest, tempfile, tarfile, warnings
 from wheel.bdist_wheel import get_abi_tag, get_platform
 from packaging.tags import interpreter_name, interpreter_version
 

--- a/test/git/test_invocations.py
+++ b/test/git/test_invocations.py
@@ -438,20 +438,6 @@ class DistutilsRepo(_Invocations, unittest.TestCase):
         self.make_distutils_wheel_with_pip()
         # asserts version as a side-effect
 
-    def test_sdist(self):
-        sdist = self.make_distutils_sdist() # asserts version as a side-effect
-        # make sure we used distutils/sdist, not setuptools/sdist
-        with tarfile.TarFile(sdist) as t:
-            self.assertFalse("demoapp2-2.0/src/demoapp2.egg-info/PKG-INFO" in
-                             t.getnames())
-
-    def test_sdist_subproject(self):
-        sdist = self.make_distutils_sdist_subproject()
-        # make sure we used distutils/sdist, not setuptools/sdist
-        with tarfile.TarFile(sdist) as t:
-            self.assertFalse("demoapp2-2.0/src/demoapp2.egg-info/PKG-INFO" in
-                             t.getnames())
-
     def test_pip_install(self):
         repodir = self.make_distutils_repo()
         venv = self.make_venv("distutils-repo-pip-install")

--- a/test/git/test_invocations.py
+++ b/test/git/test_invocations.py
@@ -676,19 +676,19 @@ class DistutilsUnpacked(_Invocations, unittest.TestCase):
         repodir = self.make_distutils_unpacked()
         venv = self.make_venv("distutils-unpacked-pip-install")
         self.run_in_venv(venv, repodir, "pip", "install", ".")
-        self.check_in_venv(venv)
+        self.check_in_venv(venv, use_python=True)
 
     def test_pip_install_subproject(self):
         unpacked = self.make_distutils_subproject_unpacked()
         venv = self.make_venv("distutils-subproject-unpacked-pip-install")
         self.run_in_venv(venv, unpacked, "pip", "install", ".")
-        self.check_in_venv(venv)
+        self.check_in_venv(venv, use_python=True)
 
     def test_pip_install_from_afar(self):
         repodir = self.make_distutils_unpacked()
         venv = self.make_venv("distutils-unpacked-pip-install-from-afar")
         self.run_in_venv(venv, venv, "pip", "install", repodir)
-        self.check_in_venv(venv)
+        self.check_in_venv(venv, use_python=True)
 
 class SetuptoolsUnpacked(_Invocations, unittest.TestCase):
     def test_install(self):

--- a/test/git/test_invocations.py
+++ b/test/git/test_invocations.py
@@ -71,13 +71,13 @@ class _Invocations(common.Common):
     def run_in_venv(self, venv, workdir, command, *args, use_python=False):
         bin_args = [self.get_venv_bin(venv, command)]
         pybin = self.get_venv_bin(venv, "python")
-        
+
         if command == "pip":
             bin_args = [pybin, "-m", "pip"]
             args = ["--isolated", "--no-cache-dir"] + list(args)
         elif command == "rundemo" and use_python:
             bin_args = [pybin] + bin_args
-        
+
         return self.command(*bin_args, *args, workdir=workdir)
 
     def check_in_venv(self, venv, use_python=False):

--- a/test/git/test_invocations.py
+++ b/test/git/test_invocations.py
@@ -53,11 +53,10 @@ class _Invocations(common.Common):
         # switching to 'venv' on py3, but only py3.4 includes pip, and even
         # then it's an ancient version.
         os.environ.pop("__PYVENV_LAUNCHER__", None)
-        virtualenv.logger = virtualenv.Logger([]) # hush
         # virtualenv causes DeprecationWarning/ResourceWarning on py3
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            virtualenv.create_environment(venv_dir)
+            self.python('-m', 'virtualenv', venv_dir, workdir=self.testdir)
             self.run_in_venv(venv_dir, venv_dir,
                              'pip', 'install', '-U',
                              'pip', 'wheel', 'packaging')

--- a/test/git/test_invocations.py
+++ b/test/git/test_invocations.py
@@ -39,7 +39,7 @@ class _Invocations(common.Common):
     def make_venv(self, mode):
         if not os.path.exists(self.subpath("venvs")):
             os.mkdir(self.subpath("venvs"))
-        venv_dir = self.subpath("venvs/%s" % mode)
+        venv_dir = self.subpath(os.path.join("venvs", mode))
         # python3 on OS-X uses a funky two-part executable and an environment
         # variable to communicate between them. If this variable is still set
         # by the time a virtualenv's 'pip' or 'python' is run, and if that

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ python =
 [gh-actions:env]
 PLATFORM =
   ubuntu-latest: linux
-  windows-latest: windows
+  windows-2019: windows
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -39,6 +39,8 @@ commands =
     pip --version
     virtualenv --version
 
+    ls {envdir}
+
     # this creates versioneer.py in the current directory, which is used by
     # tests
     python setup.py make_versioneer

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ deps =
     flake8-docstrings
     wheel>=0.35
     setuptools>=50
-    virtualenv<20
+    virtualenv>=20
     packaging>=20
     pip>=20
     !pypy3: mypy

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py36,py37,py38,py39,pypy3
+envlist = py36,py37,py38,py39,py310,pypy3
 skip_missing_interpreters = True
 
 [flake8]
@@ -16,6 +16,7 @@ python =
   3.7: py37
   3.8: py38
   3.9: py39
+  3.10: py310
   pypy-3.7: pypy3
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -39,8 +39,6 @@ commands =
     pip --version
     virtualenv --version
 
-    ls {envdir}
-
     # this creates versioneer.py in the current directory, which is used by
     # tests
     python setup.py make_versioneer


### PR DESCRIPTION
This pull request fixes #273 by simply removing the `--match` argument when `tag_prefix = ''`. No platform-dependent escaping of the asterisk needed.

As a first verification I tracked what `git describe --tags --match <Match string>` produces for each platform (Windows/Linux) and shell (cmd/powershell/bash), given different arguments for `--match`. In the table below we have a repository with two tags: `aaa-999` and `demo-1.0`. 

| Match string | Ubuntu Result | Windows Bash Result | Windows Cmd Result | Windows Powershell Result |
| :----------- | :------------ | :------------------ | :----------------- | :------------------------ |
| \<Leave out `--match`>    | aaa-999       | aaa-999             | aaa-999            | aaa-999                   |
| *            | fatal         | fatal               | aaa-999            | aaa-999                   |
| \*           | aaa-999       | aaa-999             | fatal              | fatal                     |
| demo-*       | demo-1.0      | demo-1.0            | demo-1.0           | demo-1.0                  |
| \demo-*      | demo-1.0      | demo-1.0            | demo-1.0           | demo-1.0                  |
| demo-\*      | demo-1.0      | demo-1.0            | fatal              | fatal                     |

The above suggests that we can indeed cover all cases by:
- Leaving out `--match` when `tag_prefix = ''`
- Using `--match {tag_prefix}*` otherwise

Next, I added the `test_no_tag_prefix` unittest to cover the case where `tag_prefix` is empty.

This covers the fix, but most of my efforts have actually been to get the Windows tests working to be sure that the implementation is correct. I started from #263 and added the following changes:
- Use `os.path.join` wherever possible rather than hardcoding forward-slash paths 570fcc8fe3083425770de87ebf8215f585e28bd5
- For some test projects, the `rundemo` file is a Python file that is made runnable in Linux through a shebang line. This doesn't work in Windows, so I opted to make a `python rundemo` call in these cases instead.
- `pip install -U pip` doesn't seem to work in Windows because of access issues. You need to use `python -m pip install -U pip` instead, so I changed this in the `run_in_venv` function.
- An environment made by `virtualenv<20` is not recognized by Windows in `python>=3.7` because it misses a `pyvenv.cfg` file. Therefore I switched to `virtualenv>=20` and made the necessary changes to the testing code.

A couple of attention points, open to suggestions here:
- As highlighted in #282, `distutils` are deprecated and the `test_sdist` and `test_sdist_subproject` were already failing in `master`, so I took the liberty of removing these two unittests. 
- The CI for Windows adds a lot of runtime: each job (6 python versions are tested each for Windows and Linux) took about 20 min on Windows, versus 4-5 min on Linux. Part of the reason is that I run the `test_git` script from bash, CMD and powershell when on Windows to cover the bases in the table above. Perhaps it's worth reducing the number of Python versions checked for Windows or to remove one of those extra scripts (CMD and Powershell seem to behave identically here).

 