### PR TITLE
FIX: Restore py_modules field to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -138,6 +138,10 @@ setup(
     author = "Brian Warner",
     author_email = "warner-versioneer@lothar.com",
     url = "https://github.com/python-versioneer/python-versioneer",
+    # "fake" is replaced with versioneer-installer in build_scripts. We need
+    # a non-empty list to provoke "setup.py build" into making scripts,
+    # otherwise it skips that step.
+    py_modules = ["fake"],
     entry_points={
         'console_scripts': [
             'versioneer = versioneer:main',


### PR DESCRIPTION
Lost this in #288, being a bit over-zealous and under-cautious.