### PR TITLE
FIX: skip version update on `build_ext` if .py does not exist

### DIFF
--- a/src/cmdclass.py
+++ b/src/cmdclass.py
@@ -111,6 +111,11 @@ def get_cmdclass(cmdclass=None):
             # it with an updated value
             target_versionfile = os.path.join(self.build_lib,
                                               cfg.versionfile_build)
+            if not os.path.exists(target_versionfile):
+                print(f"Warning: {target_versionfile} does not exist, skipping "
+                      "version update. This can happen if you are running build_ext "
+                      "without first running build_py.")
+                return
             print("UPDATING %s" % target_versionfile)
             write_to_version_file(target_versionfile, versions)
     cmds["build_ext"] = cmd_build_ext


### PR DESCRIPTION
Skip version update on `build_ext` command if the respective version
file does not exist.  This could be the case if `build_ext` is called
explicitly without calling `build_py` prior to it.

Closes #296