### PR TITLE
Undefined name: VersioneerBadRootError on line 51

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ def generate_long_version_py(VCS):
 
 def generate_versioneer_py():
     s = io.StringIO()
-    s.write(get("src/header.py", add_ver=True, do_readme=True))
+    s.write(get("src/header.py", add_ver=True, do_readme=True, do_strip=True))
     s.write(get("src/subprocess_helper.py", do_strip=True))
 
     for VCS in get_vcs_list():

--- a/src/header.py
+++ b/src/header.py
@@ -21,8 +21,7 @@ import sys
 from typing import Callable, Dict
 import functools
 
-from .get_versions import VersioneerBadRootError
-
+class VersioneerBadRootError(Exception): ... # --STRIP DURING BUILD
 
 class VersioneerConfig:
     """Container for Versioneer configuration parameters."""

--- a/src/header.py
+++ b/src/header.py
@@ -21,6 +21,8 @@ import sys
 from typing import Callable, Dict
 import functools
 
+from .get_versions import VersioneerBadRootError
+
 
 class VersioneerConfig:
     """Container for Versioneer configuration parameters."""


### PR DESCRIPTION
`VersioneerBadRootError` is used on line 51 but it is never imported which may result in a NameError being raised instead.