### PR TITLE
FIX: old GIT (<1.7.2) does not know about `--count` flag

### DIFF
--- a/src/git/from_vcs.py
+++ b/src/git/from_vcs.py
@@ -136,9 +136,8 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, runner=run_command):
     else:
         # HEX: no tags
         pieces["closest-tag"] = None
-        count_out, rc = runner(GITS, ["rev-list", "HEAD", "--left-right"], cwd=root)
-        count_out = len(count_out.split())
-        pieces["distance"] = int(count_out)  # total number of commits
+        out, rc = runner(GITS, ["rev-list", "HEAD", "--left-right"], cwd=root)
+        pieces["distance"] = len(out.split())  # total number of commits
 
     # commit date: see ISO-8601 comment in git_versions_from_keywords()
     date = runner(GITS, ["show", "-s", "--format=%ci", "HEAD"], cwd=root)[0].strip()

--- a/src/git/from_vcs.py
+++ b/src/git/from_vcs.py
@@ -2,7 +2,6 @@ import sys  # --STRIP DURING BUILD
 import re  # --STRIP DURING BUILD
 import os  # --STRIP DURING BUILD
 import functools  # --STRIP DURING BUILD
-from packaging import version  # --STRIP DURING BUILD
   # --STRIP DURING BUILD
   # --STRIP DURING BUILD
 def register_vcs_handler(*args):  # --STRIP DURING BUILD
@@ -137,15 +136,8 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, runner=run_command):
     else:
         # HEX: no tags
         pieces["closest-tag"] = None
-        GITS_version, rc = run_command(GITS, ["--version"], cwd=root)
-        GITS_version = GITS_version.split()[2]
-        if version.parse(GITS_version) >= version.parse("1.7.2"):
-            count_out, rc = run_command(GITS, ["rev-list", "HEAD", "--count"],
-                                        cwd=root)
-        else:
-            count_out, rc = run_command(GITS, ["rev-list", "HEAD", "--left-right"],
-                                        cwd=root)
-            count_out = len(count_out.split())
+        count_out, rc = runner(GITS, ["rev-list", "HEAD", "--left-right"], cwd=root)
+        count_out = len(count_out.split())
         pieces["distance"] = int(count_out)  # total number of commits
 
     # commit date: see ISO-8601 comment in git_versions_from_keywords()

--- a/src/git/from_vcs.py
+++ b/src/git/from_vcs.py
@@ -2,6 +2,7 @@ import sys  # --STRIP DURING BUILD
 import re  # --STRIP DURING BUILD
 import os  # --STRIP DURING BUILD
 import functools  # --STRIP DURING BUILD
+from packaging import version  # --STRIP DURING BUILD
   # --STRIP DURING BUILD
   # --STRIP DURING BUILD
 def register_vcs_handler(*args):  # --STRIP DURING BUILD
@@ -136,7 +137,15 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, runner=run_command):
     else:
         # HEX: no tags
         pieces["closest-tag"] = None
-        count_out, rc = runner(GITS, ["rev-list", "HEAD", "--count"], cwd=root)
+        GITS_version, rc = run_command(GITS, ["--version"], cwd=root)
+        GITS_version = GITS_version.split()[2]
+        if version.parse(GITS_version) >= version.parse("1.7.2"):
+            count_out, rc = run_command(GITS, ["rev-list", "HEAD", "--count"],
+                                        cwd=root)
+        else:
+            count_out, rc = run_command(GITS, ["rev-list", "HEAD", "--left-right"],
+                                        cwd=root)
+            count_out = len(count_out.split())
         pieces["distance"] = int(count_out)  # total number of commits
 
     # commit date: see ISO-8601 comment in git_versions_from_keywords()

--- a/src/header.py
+++ b/src/header.py
@@ -20,7 +20,6 @@ import subprocess
 import sys
 from typing import Callable, Dict
 import functools
-from packaging import version
 
 
 class VersioneerConfig:

--- a/src/header.py
+++ b/src/header.py
@@ -20,6 +20,7 @@ import subprocess
 import sys
 from typing import Callable, Dict
 import functools
+from packaging import version
 
 
 class VersioneerConfig:

--- a/test/git/test_git.py
+++ b/test/git/test_git.py
@@ -40,7 +40,7 @@ class ParseGitDescribe(unittest.TestCase):
                     else:
                         return "longlong\n", 0
                 if args[0] == "rev-list":
-                    return "42\n", 0
+                    return ">hashhashhashhashhashhashhashhash\n" * 42, 0
                 if args[0] == "show":
                     if do_error == "show":
                         return "gpg: signature\n12345\n", 0


### PR DESCRIPTION
Fixes #98, fixes #187.

`--count` flag comes from git v1.7.2 with commit https://github.com/git/git/commit/f69c501832ecd6880602c55565508e70c3a013d5

Note: I tried this PR on already-generated `versioneer.py`, I did not test that its generation is correct.