### PR TITLE
ENH: Patch versioneer files into manifest at runtime

### DIFF
--- a/src/git/install.py
+++ b/src/git/install.py
@@ -1,7 +1,7 @@
 import sys # --STRIP DURING BUILD
 def run_command(): pass # --STRIP DURING BUILD
 
-def do_vcs_install(manifest_in, versionfile_source, ipy):
+def do_vcs_install(versionfile_source, ipy):
     """Git-specific installation logic for Versioneer.
 
     For Git, this means creating/changing .gitattributes to mark _version.py
@@ -10,7 +10,7 @@ def do_vcs_install(manifest_in, versionfile_source, ipy):
     GITS = ["git"]
     if sys.platform == "win32":
         GITS = ["git.cmd", "git.exe"]
-    files = [manifest_in, versionfile_source]
+    files = [versionfile_source]
     if ipy:
         files.append(ipy)
     try:

--- a/src/setupfunc.py
+++ b/src/setupfunc.py
@@ -104,42 +104,10 @@ def do_setup():
         print(" %s doesn't exist, ok" % ipy)
         ipy = None
 
-    # Make sure both the top-level "versioneer.py" and versionfile_source
-    # (PKG/_version.py, used by runtime code) are in MANIFEST.in, so
-    # they'll be copied into source distributions. Pip won't be able to
-    # install the package without this.
-    manifest_in = os.path.join(root, "MANIFEST.in")
-    simple_includes = set()
-    try:
-        with open(manifest_in, "r") as f:
-            for line in f:
-                if line.startswith("include "):
-                    for include in line.split()[1:]:
-                        simple_includes.add(include)
-    except OSError:
-        pass
-    # That doesn't cover everything MANIFEST.in can do
-    # (https://packaging.python.org/en/latest/guides/using-manifest-in/#manifest-in-commands),
-    # so it might give some false negatives. Appending redundant 'include'
-    # lines is safe, though.
-    if "versioneer.py" not in simple_includes:
-        print(" appending 'versioneer.py' to MANIFEST.in")
-        with open(manifest_in, "a") as f:
-            f.write("include versioneer.py\n")
-    else:
-        print(" 'versioneer.py' already in MANIFEST.in")
-    if cfg.versionfile_source not in simple_includes:
-        print(" appending versionfile_source ('%s') to MANIFEST.in" %
-              cfg.versionfile_source)
-        with open(manifest_in, "a") as f:
-            f.write("include %s\n" % cfg.versionfile_source)
-    else:
-        print(" versionfile_source already in MANIFEST.in")
-
     # Make VCS-specific changes. For git, this means creating/changing
     # .gitattributes to mark _version.py for export-subst keyword
     # substitution.
-    do_vcs_install(manifest_in, cfg.versionfile_source, ipy)
+    do_vcs_install(cfg.versionfile_source, ipy)
     return 0
 
 

--- a/test/git/test_git.py
+++ b/test/git/test_git.py
@@ -470,8 +470,6 @@ class Repo(common.Common, unittest.TestCase):
             self.assertEqual(out[1], f" {init} doesn't exist, ok")
         else:
             self.assertEqual(out[1], f" appending to {init}")
-        self.assertEqual(out[2], " appending 'versioneer.py' to MANIFEST.in")
-        self.assertEqual(out[3], " appending versionfile_source ('src/demo/_version.py') to MANIFEST.in")
 
         # Many folks have a ~/.gitignore with ignores .pyc files, but if they
         # don't, it will show up in the status here. Ignore it.
@@ -485,7 +483,6 @@ class Repo(common.Common, unittest.TestCase):
         def pf(fn):
             return posixpath.normpath(posixpath.join(self.project_sub_dir, fn))
         expected = {"A  %s" % pf(".gitattributes"),
-                    "M  %s" % pf("MANIFEST.in"),
                     "A  %s" % pf("src/demo/_version.py"),
                     }
         if not script_only:
@@ -505,8 +502,6 @@ class Repo(common.Common, unittest.TestCase):
             self.assertEqual(out[1], f" {init} doesn't exist, ok")
         else:
             self.assertEqual(out[1], f" {init} unmodified")
-        self.assertEqual(out[2], " 'versioneer.py' already in MANIFEST.in")
-        self.assertEqual(out[3], " versionfile_source already in MANIFEST.in")
         out = set(remove_pyc(self.git("status", "--porcelain").splitlines()))
         self.assertEqual(out, set())
 


### PR DESCRIPTION
Hack egg_info to modify SOURCES.txt, adding versioneer.py and versionfile_source. versionfile_source is necessary in cases where there's a single module.py file in the root. Admittedly a boutique case, but one we test for.

This removes the need to add these files to `MANIFEST.in`, which has been a source of annoyance (#40, #247, probably others...).

Closes #40.
Addresses part of #247.