### PR TITLE
CI: Update gh-actions PLATFORM variable to avoid double-testing

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest']
-        python-version: [3.7, 3.8, 3.9, '3.10', 'pypy-3.7']
+        python-version: [3.7, 3.8, 3.9, '3.10', 'pypy3.9']
         shell: ['bash']
         include:
           - os: 'windows-latest'
@@ -35,9 +35,9 @@ jobs:
       run:
         shell: ${{ matrix.shell }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Display Python version

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ python =
   3.8: py38
   3.9: py39
   3.10: py310
-  pypy-3.7: pypy3
+  pypy-3.9: pypy3
 
 [gh-actions:env]
 PLATFORM =

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ python =
 [gh-actions:env]
 PLATFORM =
   ubuntu-latest: linux
-  windows-2019: windows
+  windows-latest: windows
 
 [testenv]
 deps =


### PR DESCRIPTION
Windows tests are taking extra long, and I think it's because we're expecting `windows-2019` when we bumped to `windows-latest` in #290.