### PR TITLE
Adequate custom `build_py` command to changes in setuptools v64

### DIFF
--- a/src/cmdclass.py
+++ b/src/cmdclass.py
@@ -69,6 +69,9 @@ def get_cmdclass(cmdclass=None):
     #   then does setup.py bdist_wheel, or sometimes setup.py install
     #  setup.py egg_info -> ?
 
+    # pip install -e . and setuptool/editable_wheel will invoke build_py
+    # but the build_py command is not expected to copy any files.
+
     # we override different "build_py" commands for both environments
     if 'build_py' in cmds:
         _build_py = cmds['build_py']
@@ -81,6 +84,10 @@ def get_cmdclass(cmdclass=None):
             cfg = get_config_from_root(root)
             versions = get_versions()
             _build_py.run(self)
+            if getattr(self, "editable_mode", False):
+                # During editable installs `.py` and data files are
+                # not copied to build_lib
+                return
             # now locate _version.py in the new build/ directory and replace
             # it with an updated value
             if cfg.versionfile_build:


### PR DESCRIPTION
`setuptools` v64 introduces the new PEP 660 hooks, which seems to be incompatible with `versioneer` (as per https://github.com/pypa/setuptools/issues/3501)

The idea of this PR is to try finding a way to make the integration with the new version work properly.

Disclaimer: I am not very familiar with `python-versioneer`, so please forgive me if there is something wrong here.

#### Deep explanation

This means that when `pip install -e .` runs, it will try to use the new `editable_wheel` command instead of `develop`.

Previously, the `develop` command special-cased `build_py` and `build_ext` and treated each command considering the knowledge on what they do.

This was problematic because custom build steps could not run during an editable install.

`editable_wheel` tries to use a more generic approach and fix the problem of custom build steps:
- all the `build` subcommands should run.
- each command have the opportunity to early return by checking if the current build is an editable install or not.

For `versioneer` the implication is that the `build_lib` directory may not contain a `_version.py` file.