### PR TITLE
ENH: in verbose mode do not hide stderr of git rev-parse

### DIFF
--- a/src/git/from_vcs.py
+++ b/src/git/from_vcs.py
@@ -35,7 +35,7 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, runner=run_command):
     runner = functools.partial(runner, env=env)
 
     _, rc = runner(GITS, ["rev-parse", "--git-dir"], cwd=root,
-                   hide_stderr=True)
+                   hide_stderr=not verbose)
     if rc != 0:
         if verbose:
             print("Directory %s not under git control" % root)


### PR DESCRIPTION
Hiding it made it very difficult to figure out why versionner was
failing to figure out the version.

Closes #310