### PR TITLE
ENH: Prepare for py2exe dropping distutils support

### DIFF
--- a/src/cmdclass.py
+++ b/src/cmdclass.py
@@ -160,7 +160,10 @@ def get_cmdclass(cmdclass=None):
         del cmds["build_py"]
 
     if 'py2exe' in sys.modules:  # py2exe enabled?
-        from py2exe.distutils_buildexe import py2exe as _py2exe
+        try:
+            from py2exe.setuptools_buildexe import py2exe as _py2exe
+        except ImportError:
+            from py2exe.distutils_buildexe import py2exe as _py2exe
 
         class cmd_py2exe(_py2exe):
             def run(self):


### PR DESCRIPTION
In https://github.com/py2exe/py2exe/issues/127, it looks like `py2exe.distutils_buildexe` will be replaced with `py2exe.setuptools_buildexe`. Getting this in now should save headaches later.