### PR TITLE
Support configuration in pyproject.toml

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -74,9 +74,20 @@ To versioneer-enable your project:
 
 * 1: Install versioneer with `pip install versioneer`
 
-* 2: Modify your `setup.cfg`, adding a section named `[versioneer]` and
+* 2: Modify your `pyproject.toml` or your `setup.cfg`,
+  adding a section named `[tool.versioneer]` or `[versioneer]` (respectively) and
   populating it with the configuration values you decided earlier (note that
   the option names are not case-sensitive):
+
+  ```toml
+  [tool.versioneer]
+  VCS = "git"
+  style = "pep440"
+  versionfile_source = "src/myproject/_version.py"
+  versionfile_build = "myproject/_version.py"
+  tag_prefix = ""
+  parentdir_prefix = "myproject-"
+  ```
 
   ```ini
   [versioneer]

--- a/README.md
+++ b/README.md
@@ -25,14 +25,16 @@ is intended to allow you to skip this step and simplify the process of upgrading
 ### Vendored mode
 
 * `pip install versioneer` to somewhere in your $PATH
-* add a `[versioneer]` section to your setup.cfg (see [Install](INSTALL.md))
+* add a `[tool.versioneer]` section to your `pyproject.toml or a
+  `[versioneer]` section to your `setup.cfg` (see [Install](INSTALL.md))
 * run `versioneer install --vendor` in your source tree, commit the results
 * verify version information with `python setup.py version`
 
 ### Build-time dependency mode
 
 * `pip install versioneer` to somewhere in your $PATH
-* add a `[versioneer]` section to your setup.cfg (see [Install](INSTALL.md))
+* add a `[tool.versioneer]` section to your `pyproject.toml or a
+  `[versioneer]` section to your `setup.cfg` (see [Install](INSTALL.md))
 * add `versioneer` to the `requires` key of the `build-system` table in
   `pyproject.toml`:
   ```toml
@@ -246,8 +248,9 @@ resolve it.
 To upgrade your project to a new release of Versioneer, do the following:
 
 * install the new Versioneer (`pip install -U versioneer` or equivalent)
-* edit `setup.cfg`, if necessary, to include any new configuration settings
-  indicated by the release notes. See [UPGRADING](./UPGRADING.md) for details.
+* edit `setup.cfg` and `pyproject.toml`, if necessary,
+  to include any new configuration settings indicated by the release notes.
+  See [UPGRADING](./UPGRADING.md) for details.
 * re-run `versioneer install --[no-]vendor` in your source tree, to replace
   `SRC/_version.py`
 * commit any changed files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,3 +31,6 @@ dynamic = ["version"]
 
 [project.scripts]
 "versioneer" = "versioneer:main"
+
+[project.optional-dependencies]
+toml = ["tomli"]

--- a/test/demoapp-pyproject/pyproject.toml
+++ b/test/demoapp-pyproject/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0", "versioneer @ @REPOROOT@"]
+requires = ["setuptools>=61.0", "versioneer[toml] @ @REPOROOT@"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -10,3 +10,10 @@ authors = [
 description = "Demo"
 requires-python = ">=3.7"
 dynamic = ["version"]
+
+[tool.versioneer]
+VCS = "@VCS@"
+versionfile_source = "src/demo/_version.py"
+versionfile_build = "demo/_version.py"
+tag_prefix = "demo-"
+parentdir_prefix = "demo-"

--- a/test/demoapp-pyproject/setup.cfg
+++ b/test/demoapp-pyproject/setup.cfg
@@ -1,6 +1,0 @@
-[versioneer]
-VCS = @VCS@
-versionfile_source = src/demo/_version.py
-versionfile_build = demo/_version.py
-tag_prefix = demo-
-parentdir_prefix = demo-

--- a/test/git/test_git.py
+++ b/test/git/test_git.py
@@ -452,18 +452,19 @@ class Repo(common.Common, unittest.TestCase):
 
         shutil.copytree(demoapp_dir, self.projdir)
         setup_cfg_fn = self.project_file("setup.cfg")
-        with open(setup_cfg_fn, "r") as f:
-            setup_cfg = f.read()
-        setup_cfg = setup_cfg.replace("@VCS@", "git")
+        if os.path.exists(setup_cfg_fn):
+            with open(setup_cfg_fn, "r") as f:
+                setup_cfg = f.read()
+            setup_cfg = setup_cfg.replace("@VCS@", "git")
 
-        tag_prefix_regex = "tag_prefix = (.*)"
-        if tag_prefix is None:
-            tag_prefix = re.search(tag_prefix_regex, setup_cfg).group(1)
-        else:
-            setup_cfg = re.sub(tag_prefix_regex, f"tag_prefix = {tag_prefix}", setup_cfg)
+            tag_prefix_regex = "tag_prefix = (.*)"
+            if tag_prefix is None:
+                tag_prefix = re.search(tag_prefix_regex, setup_cfg).group(1)
+            else:
+                setup_cfg = re.sub(tag_prefix_regex, f"tag_prefix = {tag_prefix}", setup_cfg)
 
-        with open(setup_cfg_fn, "w") as f:
-            f.write(setup_cfg)
+            with open(setup_cfg_fn, "w") as f:
+                f.write(setup_cfg)
 
         if pep518:
             # Set test versioneer build-system.requires entry to @ file:///<this-repo>
@@ -473,6 +474,15 @@ class Repo(common.Common, unittest.TestCase):
             vsr = str(versioneer_source_root).replace("\\", "/")  # For testing on Windows...
             pyproject_toml = pyproject_path.read_text()
             pyproject_toml = pyproject_toml.replace("@REPOROOT@", f"file://{vsr}")
+
+            # Update versioneer config
+            pyproject_toml = pyproject_toml.replace("@VCS@", "git")
+            tag_prefix_regex = 'tag_prefix = "(.*)"'
+            if tag_prefix is None:
+                tag_prefix = re.search(tag_prefix_regex, pyproject_toml).group(1)
+            else:
+                pyproject_toml = re.sub(tag_prefix_regex, f'tag_prefix = "{tag_prefix}"', pyproject_toml)
+
             pyproject_path.write_text(pyproject_toml)
         else:
             shutil.copyfile("versioneer.py", self.project_file("versioneer.py"))

--- a/tox.ini
+++ b/tox.ini
@@ -33,6 +33,7 @@ deps =
     packaging>=20
     pip>=20
     build
+    tomli
     !pypy3: mypy
 
 commands =


### PR DESCRIPTION
Not too difficult, now we have some tests. Need to update docs.

To consider: Support writing a sample config to pyproject.toml instead of setup.cfg, if pyproject.toml already exists.

Closes #146.