### PR TITLE
ENH: Trust the package-installed versionfile

### DIFF
--- a/src/get_versions.py
+++ b/src/get_versions.py
@@ -1,4 +1,5 @@
 import os, sys # --STRIP DURING BUILD
+import runpy # --STRIP DURING BUILD
 def get_root(): pass # --STRIP DURING BUILD
 def get_config_from_root(): pass # --STRIP DURING BUILD
 def versions_from_file(): pass # --STRIP DURING BUILD
@@ -38,6 +39,13 @@ def get_versions(verbose=False):
     # source checkout, for users of a tarball created by 'setup.py sdist',
     # and for users of a tarball/zipball created by 'git archive' or github's
     # download-from-tag feature or the equivalent in other VCSes.
+
+    # First, can we just load the module?
+    try:
+        version_module = runpy.run_module(versionfile_abs)
+        return version_module['get_versions'](verbose=verbose)
+    except Exception:
+        pass
 
     get_keywords_f = handlers.get("get_keywords")
     from_keywords_f = handlers.get("keywords")

--- a/src/header.py
+++ b/src/header.py
@@ -16,6 +16,7 @@ import errno
 import json
 import os
 import re
+import runpy
 import subprocess
 import sys
 from pathlib import Path


### PR DESCRIPTION
Some packages have hacked versioneer to use custom overrides or fallbacks, which makes the process of upgrading somewhat painful, and prevents switching to the non-vendored versioneer. The current versioneer does not execute the contents of `_version.py`, but just greps for certain values before falling back to its own methods.

This PR causes `versioneer.get_versions()` to first attempt to run `_version.get_versions()` before falling back.