### PR TITLE
Useless inheritance from object

### DIFF
--- a/test/test_render.py
+++ b/test/test_render.py
@@ -3,7 +3,7 @@ import unittest
 from versioneer import render
 
 
-class Testing_renderer_case_mixin(object):
+class Testing_renderer_case_mixin:
     """
     This is a mixin object which can be combined with a unittest.TestCase
     which defines a style and an expected dictionary. See Test_pep440 for


### PR DESCRIPTION
[Useless inheritance from `object` PYL-R0205](https://deepsource.io/gh/DimitriPapadopoulos/python-versioneer/issue/PYL-R0205/occurrences)

> The class is inheriting from object, which is implicit under Python 3, hence can be safely removed from bases.