### PR TITLE
Merge `endswith` checks

### DIFF
--- a/src/git/install.py
+++ b/src/git/install.py
@@ -16,7 +16,7 @@ def do_vcs_install(versionfile_source, ipy):
     if "VERSIONEER_PEP518" not in globals():
         try:
             my_path = __file__
-            if my_path.endswith(".pyc") or my_path.endswith(".pyo"):
+            if my_path.endswith((".pyc", ".pyo")):
                 my_path = os.path.splitext(my_path)[0] + ".py"
             versioneer_file = os.path.relpath(my_path)
         except NameError:


### PR DESCRIPTION
[Consider merging `startswith`/`endswith` checks PY-W0077](https://deepsource.io/gh/DimitriPapadopoulos/python-versioneer/issue/PY-W0077/occurrences)

> The methods `startswith` and `endswith` for string instances accept two types of Python constructs as the first argument. The types are:
> - a Python string, or
> - a tuple of strings