### PR TITLE
CI: python-version should be a string, not a float

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest']
-        python-version: [3.7, 3.8, 3.9, '3.10', 'pypy3.9']
+        python-version: ['3.7', '3.8', '3.9', '3.10', 'pypy3.9']
         shell: ['bash']
         include:
           - os: 'windows-latest'


### PR DESCRIPTION
This shows clearly with `'3.10'` which is different from `'3.1'`.