### PR TITLE
FIX: mixup between _egg_info and _sdist

### DIFF
--- a/src/cmdclass.py
+++ b/src/cmdclass.py
@@ -189,7 +189,7 @@ def get_cmdclass(cmdclass=None):
 
     # sdist farms its file list building out to egg_info
     if 'egg_info' in cmds:
-        _sdist = cmds['egg_info']
+        _egg_info = cmds['egg_info']
     else:
         from setuptools.command.egg_info import egg_info as _egg_info
 

--- a/test/demoapp2-setuptools/setup.py
+++ b/test/demoapp2-setuptools/setup.py
@@ -2,6 +2,8 @@
 from setuptools import setup
 import versioneer
 commands = versioneer.get_cmdclass().copy()
+# Updating our updated commands should be safe
+commands = versioneer.get_cmdclass(commands).copy()
 
 setup(name="demoapp2",
       version=versioneer.get_version(),


### PR DESCRIPTION
This fixes the following error message that appeared when upgrading Numpy from Versioneer 0.19 to 0.26:
```
Traceback (most recent call last):
  File "setup.py", line 102, in <module>
    cmdclass = versioneer.get_cmdclass(numpy_cmdclass)
  File "/cygdrive/d/a/numpy/numpy/versioneer.py", line 1980, in get_cmdclass
    class cmd_egg_info(_egg_info):
UnboundLocalError: local variable '_egg_info' referenced before assignment
```