### PR TITLE
FIX: Always bootstrap in setup.py to avoid incompatibility with old versioneer

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import os, base64, tempfile, io
+from importlib import util as ilu
 from pathlib import Path
 from setuptools import setup, Command
 from setuptools.command.build_py import build_py
@@ -132,13 +133,9 @@ class develop(develop):
     def run(self):
         raise RuntimeError("Versioneer cannot be installed in developer/editable mode.")
 
-try:
-    import versioneer
-except ImportError:
-    # Bootstrap a versioneer module until it's built
-    from importlib import util as ilu
-    versioneer = ilu.module_from_spec(ilu.spec_from_loader('versioneer', loader=None))
-    exec(generate_versioneer_py(), versioneer.__dict__)
+# Bootstrap a versioneer module to guarantee that we get a compatible version
+versioneer = ilu.module_from_spec(ilu.spec_from_loader('versioneer', loader=None))
+exec(generate_versioneer_py(), versioneer.__dict__)
 
 VERSION = versioneer.get_version()
 


### PR DESCRIPTION
Always bootstrap versioneer and use the newly bootstrapped version in `setup.py`.  This avoids compatibility problems when there is an old version of versioneer installed (<= 0.23) that does not define `get_version()` and therefore causes `setup.py` to fail.

Thanks to Chris Markiewicz for the suggested solution.

Fixes #343