### PR TITLE
FIX: handle unset versionfile_build in build_ext

### DIFF
--- a/src/cmdclass.py
+++ b/src/cmdclass.py
@@ -116,6 +116,8 @@ def get_cmdclass(cmdclass=None):
                 return
             # now locate _version.py in the new build/ directory and replace
             # it with an updated value
+            if not cfg.versionfile_build:
+                return
             target_versionfile = os.path.join(self.build_lib,
                                               cfg.versionfile_build)
             if not os.path.exists(target_versionfile):


### PR DESCRIPTION
Fix a crash due to attempting to pass `None` to `os.path.join()` when `versionfile_build` is not set in the config file, and `build_ext` command is called directly.

Fixes #346