### PR TITLE
FIX: cx_freeze changed the path to build_exe

### DIFF
--- a/src/cmdclass.py
+++ b/src/cmdclass.py
@@ -130,7 +130,7 @@ def get_cmdclass(cmdclass=None):
     cmds["build_ext"] = cmd_build_ext
 
     if "cx_Freeze" in sys.modules:  # cx_freeze enabled?
-        from cx_Freeze.dist import build_exe as _build_exe
+        from cx_Freeze.command.build_exe import BuildEXE as _build_exe
         # nczeczulin reports that py2exe won't like the pep440-style string
         # as FILEVERSION, but it can be used for PRODUCTVERSION, e.g.
         # setup(console=[{


### PR DESCRIPTION
they changed the path and the name in v6.11