### PR TITLE
MNT: Remove CJM as maintainer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ authors = [
   { name = "Brian Warner" },
 ]
 maintainers = [
-  { name = "Christopher Markiewicz", email = "effigies@gmail.com" },
   { name = "Nathan Buckner",  email = "bucknerns@users.noreply.github.com" },
 ]
 readme = "README.md"


### PR DESCRIPTION
I'm stepping down as a maintainer of this project. I'm transitioning my packages away from setuptools and versioneer to alternative backends like flit and hatchling, and I don't have time to maintain packages I don't use.

I think I achieved the things I wanted to in this package, with the exception of handling override and fallback versions.