### PR TITLE
FIX: add name to setup.py to resolve GitHub dependency graph bug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -141,6 +141,7 @@ VERSION = versioneer.get_version()
 
 
 setup(
+    name="versioneer",  # need by GitHub dependency graph
     version=VERSION,
     py_modules=["versioneer"],
     cmdclass=versioneer.get_cmdclass({


### PR DESCRIPTION
Currently the [dependency graph](https://github.com/python-versioneer/python-versioneer/network/dependents) does not show any dependents due to a [limitation with GitHub](https://github.com/orgs/community/discussions/6456).

This is fixed by repeating the project name in `setup.py`.