### PR TITLE
FIX: add message info when loading toml failed

### DIFF
--- a/src/header.py
+++ b/src/header.py
@@ -91,8 +91,9 @@ def get_config_from_root(root):
             with open(pyproject_toml, 'rb') as fobj:
                 pp = tomllib.load(fobj)
             section = pp['tool']['versioneer']
-        except (tomllib.TOMLDecodeError, KeyError):
-            pass
+        except (tomllib.TOMLDecodeError, KeyError) as e:
+            print(f"Failed to load config from {pyproject_toml}: {e}")
+            print("Try to load it from setup.cfg")
     if not section:
         parser = configparser.ConfigParser()
         with open(setup_cfg) as cfg_file:


### PR DESCRIPTION
Current version of versioneer will automatically skip it if load `pyproject.toml` failed, and try to load config from `setup.cfg`. 
If someone use versioneer in his project and unluckily there are some mistakes on his `pyproject.toml`, he will get a `FileNotFoundError` about the miss of `setup.cfg`. This is confusive to him.

So I add a info message to make him realize his `pyproject.toml` contains some mistakes(e.g. key depulication). Otherwise, he may spend a lot of time to find why versioneer try to load `setup.cfg` file which not used in his project.