### PR TITLE
Add Type Annotations for `git_version.py`

### DIFF
--- a/src/cmdclass.py
+++ b/src/cmdclass.py
@@ -1,9 +1,7 @@
 import os, sys # --STRIP DURING BUILD
-LONG_VERSION_PY = {} # --STRIP DURING BUILD
-def get_versions(): pass # --STRIP DURING BUILD
-def get_root(): pass # --STRIP DURING BUILD
-def get_config_from_root(): pass # --STRIP DURING BUILD
-def write_to_version_file(): pass # --STRIP DURING BUILD
+from .header import LONG_VERSION_PY, get_root, get_config_from_root # --STRIP DURING BUILD
+from .get_versions import get_versions # --STRIP DURING BUILD
+from .from_file import write_to_version_file # --STRIP DURING BUILD
 
 
 def get_cmdclass(cmdclass=None):

--- a/src/cmdclass.py
+++ b/src/cmdclass.py
@@ -1,6 +1,5 @@
 import os, sys # --STRIP DURING BUILD
 LONG_VERSION_PY = {} # --STRIP DURING BUILD
-def get_version(): pass # --STRIP DURING BUILD
 def get_versions(): pass # --STRIP DURING BUILD
 def get_root(): pass # --STRIP DURING BUILD
 def get_config_from_root(): pass # --STRIP DURING BUILD

--- a/src/from_file.py
+++ b/src/from_file.py
@@ -17,7 +17,7 @@ def get_versions():
 
 import json # --STRIP DURING BUILD
 import re # --STRIP DURING BUILD
-class NotThisMethod(Exception): pass  # --STRIP DURING BUILD
+from .header import NotThisMethod # --STRIP DURING BUILD
 
 def versions_from_file(filename):
     """Try to determine the version from _version.py if present."""

--- a/src/from_parentdir.py
+++ b/src/from_parentdir.py
@@ -1,5 +1,5 @@
 import os # --STRIP DURING BUILD
-class NotThisMethod(Exception): pass  # --STRIP DURING BUILD
+from .header import NotThisMethod # --STRIP DURING BUILD
 def versions_from_parentdir(parentdir_prefix, root, verbose):
     """Try to determine the version from the parent directory name.
 

--- a/src/from_parentdir.py
+++ b/src/from_parentdir.py
@@ -1,6 +1,11 @@
 import os # --STRIP DURING BUILD
 from .header import NotThisMethod # --STRIP DURING BUILD
-def versions_from_parentdir(parentdir_prefix, root, verbose):
+from typing import Any, Dict # --STRIP DURING BUILD
+def versions_from_parentdir(
+    parentdir_prefix: str,
+    root: str,
+    verbose: bool,
+) -> Dict[str, Any]:
     """Try to determine the version from the parent directory name.
 
     Source tarballs conventionally unpack into a directory that includes both

--- a/src/get_versions.py
+++ b/src/get_versions.py
@@ -1,11 +1,9 @@
 import os, sys # --STRIP DURING BUILD
-def get_root(): pass # --STRIP DURING BUILD
-def get_config_from_root(): pass # --STRIP DURING BUILD
-def versions_from_file(): pass # --STRIP DURING BUILD
-def versions_from_parentdir(): pass # --STRIP DURING BUILD
-def render(): pass # --STRIP DURING BUILD
-HANDLERS = {} # --STRIP DURING BUILD
-class NotThisMethod(Exception): pass  # --STRIP DURING BUILD
+from .header import HANDLERS, get_root, get_config_from_root # --STRIP DURING BUILD
+from .header import NotThisMethod # --STRIP DURING BUILD
+from .from_file import versions_from_file # --STRIP DURING BUILD
+from .from_parentdir import versions_from_parentdir # --STRIP DURING BUILD
+from .render import render # --STRIP DURING BUILD
 
 class VersioneerBadRootError(Exception):
     """The project root directory is unknown or missing key files."""

--- a/src/git/from_keywords.py
+++ b/src/git/from_keywords.py
@@ -1,13 +1,14 @@
 import re # --STRIP DURING BUILD
+from typing import Any, Dict # --STRIP DURING BUILD
 from .long_header import NotThisMethod, register_vcs_handler # --STRIP DURING BUILD
 @register_vcs_handler("git", "get_keywords")
-def git_get_keywords(versionfile_abs):
+def git_get_keywords(versionfile_abs: str) -> Dict[str, str]:
     """Extract version information from the given file."""
     # the code embedded in _version.py can just fetch the value of these
     # keywords. When used from setup.py, we don't want to import _version.py,
     # so we do it with a regexp instead. This function is not used from
     # _version.py.
-    keywords = {}
+    keywords: Dict[str, str] = {}
     try:
         with open(versionfile_abs, "r") as fobj:
             for line in fobj:
@@ -29,7 +30,11 @@ def git_get_keywords(versionfile_abs):
 
 
 @register_vcs_handler("git", "keywords")
-def git_versions_from_keywords(keywords, tag_prefix, verbose):
+def git_versions_from_keywords(
+    keywords: Dict[str, str],
+    tag_prefix: str,
+    verbose: bool,
+) -> Dict[str, Any]:
     """Get version information from git keywords."""
     if "refnames" not in keywords:
         raise NotThisMethod("Short version file found")

--- a/src/git/from_keywords.py
+++ b/src/git/from_keywords.py
@@ -1,9 +1,5 @@
 import re # --STRIP DURING BUILD
-def register_vcs_handler(*args): # --STRIP DURING BUILD
-    def nil(f): # --STRIP DURING BUILD
-        return f # --STRIP DURING BUILD
-    return nil # --STRIP DURING BUILD
-class NotThisMethod(Exception): pass  # --STRIP DURING BUILD
+from .long_header import NotThisMethod, register_vcs_handler # --STRIP DURING BUILD
 @register_vcs_handler("git", "get_keywords")
 def git_get_keywords(versionfile_abs):
     """Extract version information from the given file."""

--- a/src/git/from_vcs.py
+++ b/src/git/from_vcs.py
@@ -2,19 +2,10 @@ import sys  # --STRIP DURING BUILD
 import re  # --STRIP DURING BUILD
 import os  # --STRIP DURING BUILD
 import functools  # --STRIP DURING BUILD
+from .long_header import NotThisMethod, register_vcs_handler  # --STRIP DURING BUILD
+from subprocess_helper import run_command  # --STRIP DURING BUILD
   # --STRIP DURING BUILD
   # --STRIP DURING BUILD
-def register_vcs_handler(*args):  # --STRIP DURING BUILD
-    def nil(f):  # --STRIP DURING BUILD
-        return f  # --STRIP DURING BUILD
-    return nil  # --STRIP DURING BUILD
-  # --STRIP DURING BUILD
-  # --STRIP DURING BUILD
-def run_command(): pass  # --STRIP DURING BUILD
-  # --STRIP DURING BUILD
-  # --STRIP DURING BUILD
-class NotThisMethod(Exception):  # --STRIP DURING BUILD
-    pass  # --STRIP DURING BUILD
 @register_vcs_handler("git", "pieces_from_vcs")
 def git_pieces_from_vcs(tag_prefix, root, verbose, runner=run_command):
     """Get version from 'git describe' in the root of the source tree.

--- a/src/git/from_vcs.py
+++ b/src/git/from_vcs.py
@@ -2,12 +2,18 @@ import sys  # --STRIP DURING BUILD
 import re  # --STRIP DURING BUILD
 import os  # --STRIP DURING BUILD
 import functools  # --STRIP DURING BUILD
+from typing import Any, Callable, Dict  # --STRIP DURING BUILD
 from .long_header import NotThisMethod, register_vcs_handler  # --STRIP DURING BUILD
 from subprocess_helper import run_command  # --STRIP DURING BUILD
   # --STRIP DURING BUILD
   # --STRIP DURING BUILD
 @register_vcs_handler("git", "pieces_from_vcs")
-def git_pieces_from_vcs(tag_prefix, root, verbose, runner=run_command):
+def git_pieces_from_vcs(
+    tag_prefix: str,
+    root: str,
+    verbose: bool,
+    runner: Callable = run_command
+) -> Dict[str, Any]:
     """Get version from 'git describe' in the root of the source tree.
 
     This only gets called if the git-archive 'subst' keywords were *not*
@@ -47,7 +53,7 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, runner=run_command):
         raise NotThisMethod("'git rev-parse' failed")
     full_out = full_out.strip()
 
-    pieces = {}
+    pieces: Dict[str, Any] = {}
     pieces["long"] = full_out
     pieces["short"] = full_out[:7]  # maybe improved later
     pieces["error"] = None

--- a/src/git/install.py
+++ b/src/git/install.py
@@ -1,5 +1,5 @@
 import sys # --STRIP DURING BUILD
-def run_command(): pass # --STRIP DURING BUILD
+from subprocess_helper import run_command # --STRIP DURING BUILD
 
 def do_vcs_install(versionfile_source, ipy):
     """Git-specific installation logic for Versioneer.

--- a/src/git/long_get_versions.py
+++ b/src/git/long_get_versions.py
@@ -1,11 +1,12 @@
 import os # --STRIP DURING BUILD
+from typing import Any, Dict # --STRIP DURING BUILD
 from .long_header import get_config, get_keywords, NotThisMethod # --STRIP DURING BUILD
 from .from_keywords import git_versions_from_keywords # --STRIP DURING BUILD
 from .from_vcs import git_pieces_from_vcs # --STRIP DURING BUILD
 from from_parentdir import versions_from_parentdir # --STRIP DURING BUILD
 from render import render # --STRIP DURING BUILD
 
-def get_versions():
+def get_versions() -> Dict[str, Any]:
     """Get version information or return default if unable to do so."""
     # I am in _version.py, which lives at ROOT/VERSIONFILE_SOURCE. If we have
     # __file__, we can work backwards from there to the root. Some

--- a/src/git/long_get_versions.py
+++ b/src/git/long_get_versions.py
@@ -1,11 +1,9 @@
 import os # --STRIP DURING BUILD
-def get_config(): pass # --STRIP DURING BUILD
-def get_keywords(): pass # --STRIP DURING BUILD
-def git_versions_from_keywords(): pass # --STRIP DURING BUILD
-def git_pieces_from_vcs(): pass # --STRIP DURING BUILD
-def versions_from_parentdir(): pass # --STRIP DURING BUILD
-class NotThisMethod(Exception): pass  # --STRIP DURING BUILD
-def render(): pass # --STRIP DURING BUILD
+from .long_header import get_config, get_keywords, NotThisMethod # --STRIP DURING BUILD
+from .from_keywords import git_versions_from_keywords # --STRIP DURING BUILD
+from .from_vcs import git_pieces_from_vcs # --STRIP DURING BUILD
+from from_parentdir import versions_from_parentdir # --STRIP DURING BUILD
+from render import render # --STRIP DURING BUILD
 
 def get_versions():
     """Get version information or return default if unable to do so."""

--- a/src/git/long_header.py
+++ b/src/git/long_header.py
@@ -15,7 +15,7 @@ import os
 import re
 import subprocess
 import sys
-from typing import Callable, Dict, Optional
+from typing import Any, Callable, Dict, List, Optional, Tuple
 import functools
 
 

--- a/src/git/long_header.py
+++ b/src/git/long_header.py
@@ -35,13 +35,12 @@ def get_keywords() -> Dict[str, str]:
 class VersioneerConfig:
     """Container for Versioneer configuration parameters."""
 
-    VCS: Optional[str]
-    style: Optional[str]
-    versionfile_source: Optional[str]
-    versionfile_build: Optional[str]
-    tag_prefix: Optional[str]
-    parentdir_prefix: Optional[str]
-    verbose: Optional[bool]
+    VCS: str
+    style: str
+    tag_prefix: str
+    parentdir_prefix: str
+    versionfile_source: str
+    verbose: bool
 
 
 def get_config() -> VersioneerConfig:

--- a/src/git/long_header.py
+++ b/src/git/long_header.py
@@ -15,11 +15,11 @@ import os
 import re
 import subprocess
 import sys
-from typing import Callable, Dict
+from typing import Callable, Dict, Optional
 import functools
 
 
-def get_keywords():
+def get_keywords() -> Dict[str, str]:
     """Get the keywords needed to look up the version information."""
     # these strings will be replaced by git during git-archive.
     # setup.py/versioneer.py will grep for the variable names, so they must
@@ -35,8 +35,16 @@ def get_keywords():
 class VersioneerConfig:
     """Container for Versioneer configuration parameters."""
 
+    VCS: Optional[str]
+    style: Optional[str]
+    versionfile_source: Optional[str]
+    versionfile_build: Optional[str]
+    tag_prefix: Optional[str]
+    parentdir_prefix: Optional[str]
+    verbose: Optional[bool]
 
-def get_config():
+
+def get_config() -> VersioneerConfig:
     """Create, populate and return the VersioneerConfig() object."""
     # these strings are filled in when 'setup.py versioneer' creates
     # _version.py
@@ -58,9 +66,9 @@ LONG_VERSION_PY: Dict[str, str] = {}
 HANDLERS: Dict[str, Dict[str, Callable]] = {}
 
 
-def register_vcs_handler(vcs, method):  # decorator
+def register_vcs_handler(vcs: str, method: str) -> Callable:  # decorator
     """Create decorator to mark a method as the handler of a VCS."""
-    def decorate(f):
+    def decorate(f: Callable) -> Callable:
         """Store f in HANDLERS[vcs][method]."""
         if vcs not in HANDLERS:
             HANDLERS[vcs] = {}

--- a/src/header.py
+++ b/src/header.py
@@ -19,7 +19,7 @@ import re
 import subprocess
 import sys
 from pathlib import Path
-from typing import Callable, Dict
+from typing import Any, Callable, Dict, List, Optional, Tuple
 import functools
 
 have_tomllib = True

--- a/src/header.py
+++ b/src/header.py
@@ -31,7 +31,7 @@ else:
     except ImportError:
         have_tomllib = False
 
-class VersioneerBadRootError(Exception): ... # --STRIP DURING BUILD
+from .get_versions import VersioneerBadRootError # --STRIP DURING BUILD
 
 class VersioneerConfig:
     """Container for Versioneer configuration parameters."""

--- a/src/render.py
+++ b/src/render.py
@@ -1,12 +1,13 @@
+from typing import Any, Dict, Optional, Tuple # --STRIP DURING BUILD
 
-def plus_or_dot(pieces):
+def plus_or_dot(pieces: Dict[str, Any]) -> str:
     """Return a + if we don't already have one, else return a ."""
     if "+" in pieces.get("closest-tag", ""):
         return "."
     return "+"
 
 
-def render_pep440(pieces):
+def render_pep440(pieces: Dict[str, Any]) -> str:
     """Build up version string, with post-release "local version identifier".
 
     Our goal: TAG[+DISTANCE.gHEX[.dirty]] . Note that if you
@@ -31,7 +32,7 @@ def render_pep440(pieces):
     return rendered
 
 
-def render_pep440_branch(pieces):
+def render_pep440_branch(pieces: Dict[str, Any]) -> str:
     """TAG[[.dev0]+DISTANCE.gHEX[.dirty]] .
 
     The ".dev0" means not master branch. Note that .dev0 sorts backwards
@@ -61,7 +62,7 @@ def render_pep440_branch(pieces):
     return rendered
 
 
-def pep440_split_post(ver):
+def pep440_split_post(ver: str) -> Tuple[str, Optional[int]]:
     """Split pep440 version string at the post-release segment.
 
     Returns the release segments before the post-release and the
@@ -71,7 +72,7 @@ def pep440_split_post(ver):
     return vc[0], int(vc[1] or 0) if len(vc) == 2 else None
 
 
-def render_pep440_pre(pieces):
+def render_pep440_pre(pieces: Dict[str, Any]) -> str:
     """TAG[.postN.devDISTANCE] -- No -dirty.
 
     Exceptions:
@@ -95,7 +96,7 @@ def render_pep440_pre(pieces):
     return rendered
 
 
-def render_pep440_post(pieces):
+def render_pep440_post(pieces: Dict[str, Any]) -> str:
     """TAG[.postDISTANCE[.dev0]+gHEX] .
 
     The ".dev0" means dirty. Note that .dev0 sorts backwards
@@ -122,7 +123,7 @@ def render_pep440_post(pieces):
     return rendered
 
 
-def render_pep440_post_branch(pieces):
+def render_pep440_post_branch(pieces: Dict[str, Any]) -> str:
     """TAG[.postDISTANCE[.dev0]+gHEX[.dirty]] .
 
     The ".dev0" means not master branch.
@@ -151,7 +152,7 @@ def render_pep440_post_branch(pieces):
     return rendered
 
 
-def render_pep440_old(pieces):
+def render_pep440_old(pieces: Dict[str, Any]) -> str:
     """TAG[.postDISTANCE[.dev0]] .
 
     The ".dev0" means dirty.
@@ -173,7 +174,7 @@ def render_pep440_old(pieces):
     return rendered
 
 
-def render_git_describe(pieces):
+def render_git_describe(pieces: Dict[str, Any]) -> str:
     """TAG[-DISTANCE-gHEX][-dirty].
 
     Like 'git describe --tags --dirty --always'.
@@ -193,7 +194,7 @@ def render_git_describe(pieces):
     return rendered
 
 
-def render_git_describe_long(pieces):
+def render_git_describe_long(pieces: Dict[str, Any]) -> str:
     """TAG-DISTANCE-gHEX[-dirty].
 
     Like 'git describe --tags --dirty --always -long'.
@@ -213,7 +214,7 @@ def render_git_describe_long(pieces):
     return rendered
 
 
-def render(pieces, style):
+def render(pieces: Dict[str, Any], style: str) -> Dict[str, Any]:
     """Render the given version pieces into the requested style."""
     if pieces["error"]:
         return {"version": "unknown",

--- a/src/setupfunc.py
+++ b/src/setupfunc.py
@@ -1,10 +1,9 @@
 
+import configparser # --STRIP DURING BUILD
 import os, sys  # --STRIP DURING BUILD
-def get_root(): pass # --STRIP DURING BUILD
-def get_config_from_root(): pass # --STRIP DURING BUILD
-LONG_VERSION_PY = {} # --STRIP DURING BUILD
-def do_vcs_install(): pass # --STRIP DURING BUILD
-configparser = None # --STRIP DURING BUILD
+from .header import get_config_from_root, get_root # --STRIP DURING BUILD
+from .header import LONG_VERSION_PY # --STRIP DURING BUILD
+from .git.install import do_vcs_install # --STRIP DURING BUILD
 
 CONFIG_ERROR = """
 setup.cfg is missing the necessary Versioneer configuration. You need

--- a/src/subprocess_helper.py
+++ b/src/subprocess_helper.py
@@ -1,11 +1,18 @@
 import sys, subprocess, errno # --STRIP DURING BUILD
-def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
-                env=None):
+from typing import Any, Dict, List, Optional, Tuple # --STRIP DURING BUILD
+def run_command(
+    commands: List[str],
+    args: List[str],
+    cwd: Optional[str] = None,
+    verbose: bool = False,
+    hide_stderr: bool = False,
+    env: Optional[Dict[str, str]] = None,
+) -> Tuple[Optional[str], Optional[int]]:
     """Call the given command(s)."""
     assert isinstance(commands, list)
     process = None
 
-    popen_kwargs = {}
+    popen_kwargs: Dict[str, Any] = {}
     if sys.platform == "win32":
         # This hides the console window if pythonw.exe is used
         startupinfo = subprocess.STARTUPINFO()

--- a/src/subprocess_helper.py
+++ b/src/subprocess_helper.py
@@ -28,8 +28,7 @@ def run_command(
                                        stderr=(subprocess.PIPE if hide_stderr
                                                else None), **popen_kwargs)
             break
-        except OSError:
-            e = sys.exc_info()[1]
+        except OSError as e:
             if e.errno == errno.ENOENT:
                 continue
             if verbose:

--- a/test/git/test_invocations.py
+++ b/test/git/test_invocations.py
@@ -307,7 +307,9 @@ class _Invocations(common.Common):
 
     def make_binary_wheelname(self, app):
         return "%s-2.0-%s-%s-%s.whl" % (app,
-            "".join([impl, impl_ver]), abi, plat.replace("-", "_"))
+            "".join([impl, impl_ver]), abi,
+            plat.replace("-", "_").replace(".", "_")
+            )
 
 
 class SetuptoolsRepo(_Invocations, unittest.TestCase):


### PR DESCRIPTION
Over in #298 it was suggested we wanted type annotations and that a PR would be welcome.

This PR does roughly the minimum to enable type annotations on `git_version.py`

If I have further time I'll create new PRs for the rest of the src repo, add typing in tests, as well as do some better Typing in a few places (TypedDict, better typing on the decorators and vcs hooks, etc.)

But in the meantime wanted to submit this.

Additional changes that are not strictly typing:
* Use `exception OSError as e` instead of relying on the `sys.exc_info` to get the exception class.  This is ok now that py2.7 is no longer supported [and necessary for better typing since the former method typed it as `BaseException` which didn't have `errno` as a property.
* Supported my local testing on mac (using the linux tox target) by replacing `.` with `_` in the binary wheel name expectation.
* Converted the class/function definitions in the various files (where `# --STRIP DURING BUILD` was used) to actual imports that didn't fail the tests.  This so that python editors (such as VSCode) gave better type hinting in the various files, without the need to type-hint all the redefinitions themselves