### PR TITLE
Add type checking to entire versioneer project (excluding tests)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,10 @@
 import os, base64, tempfile, io
 from importlib import util as ilu
 from pathlib import Path
+from typing import List, Tuple
 from setuptools import setup, Command
 from setuptools.command.build_py import build_py
-from setuptools.command.develop import develop
+from setuptools.command.develop import develop as _develop
 
 # If versioneer is not installed in the environment, then we will need to
 # need to build and exec it. The build requires a VERSION, so we might need
@@ -13,10 +14,16 @@ from setuptools.command.develop import develop
 VERSION = "0+bootstrap"
 
 
-def ver(s):
+def ver(s: str) -> str:
     return s.replace("@VERSIONEER-VERSION@", VERSION)
 
-def get(fn, add_ver=False, unquote=False, do_strip=False, do_readme=False):
+def get(
+    fn: str,
+    add_ver: bool = False,
+    unquote: bool = False,
+    do_strip: bool = False,
+    do_readme: bool = False
+) -> str:
     with open(fn) as f:
         text = f.read()
 
@@ -31,14 +38,14 @@ def get(fn, add_ver=False, unquote=False, do_strip=False, do_readme=False):
         text = text.replace("@README@", get("README.md"))
     return text
 
-def get_vcs_list():
+def get_vcs_list() -> List[str]:
     project_path = Path(__file__).absolute().parent / "src"
     return [filename
             for filename
             in os.listdir(str(project_path))
             if Path.is_dir(project_path / filename) and filename != "__pycache__"]
 
-def generate_long_version_py(VCS):
+def generate_long_version_py(VCS: str) -> str:
     s = io.StringIO()
     s.write(get(f"src/{VCS}/long_header.py", add_ver=True, do_strip=True))
     for piece in ["src/subprocess_helper.py",
@@ -50,7 +57,7 @@ def generate_long_version_py(VCS):
         s.write(get(piece, unquote=True, do_strip=True))
     return s.getvalue()
 
-def generate_versioneer_py():
+def generate_versioneer_py() -> bytes:
     s = io.StringIO()
     s.write(get("src/header.py", add_ver=True, do_readme=True, do_strip=True))
     s.write(get("src/subprocess_helper.py", do_strip=True))
@@ -78,26 +85,25 @@ def generate_versioneer_py():
 
 class make_versioneer(Command):
     description = "create standalone versioneer.py"
-    user_options = []
-    boolean_options = []
-    def initialize_options(self):
+    user_options: List[Tuple[str, str, str]] = []
+    boolean_options: List[str] = []
+    def initialize_options(self) -> None:
         pass
-    def finalize_options(self):
+    def finalize_options(self) -> None:
         pass
-    def run(self):
+    def run(self) -> None:
         with open("versioneer.py", "w") as f:
             f.write(generate_versioneer_py().decode("utf8"))
-        return 0
 
 class make_long_version_py_git(Command):
     description = "create standalone _version.py (for git)"
-    user_options = []
-    boolean_options = []
-    def initialize_options(self):
+    user_options: List[Tuple[str, str, str]] = []
+    boolean_options: List[str] = []
+    def initialize_options(self) -> None:
         pass
-    def finalize_options(self):
+    def finalize_options(self) -> None:
         pass
-    def run(self):
+    def run(self) -> None:
         assert os.path.exists("versioneer.py")
         long_version = generate_long_version_py("git")
         with open("git_version.py", "w") as f:
@@ -108,10 +114,9 @@ class make_long_version_py_git(Command):
                      "PARENTDIR_PREFIX": "parentdir_prefix",
                      "VERSIONFILE_SOURCE": "versionfile_source",
                      })
-        return 0
 
 class my_build_py(build_py):
-    def run(self):
+    def run(self) -> None:
         v = generate_versioneer_py()
         v_b64 = base64.b64encode(v).decode("ascii")
         lines = [v_b64[i:i+60] for i in range(0, len(v_b64), 60)]
@@ -124,17 +129,18 @@ class my_build_py(build_py):
             installer.write_text(s)
 
             self.package_dir.update({'': os.path.relpath(installer.parent)})
-            rc = build_py.run(self)
-        return rc
+            build_py.run(self)
 
 # The structure of versioneer, with its components that are compiled into a single file,
 # makes it unsuitable for development mode.
-class develop(develop):
-    def run(self):
+class develop(_develop):
+    def run(self) -> None:  # type: ignore[override]
         raise RuntimeError("Versioneer cannot be installed in developer/editable mode.")
 
 # Bootstrap a versioneer module to guarantee that we get a compatible version
-versioneer = ilu.module_from_spec(ilu.spec_from_loader('versioneer', loader=None))
+versioneer = ilu.module_from_spec(
+    ilu.spec_from_loader('versioneer', loader=None)  # type: ignore[arg-type]
+)
 exec(generate_versioneer_py(), versioneer.__dict__)
 
 VERSION = versioneer.get_version()

--- a/src/cmdclass.py
+++ b/src/cmdclass.py
@@ -1,10 +1,11 @@
 import os, sys # --STRIP DURING BUILD
+from typing import Any, Dict, List, Optional, Tuple # --STRIP DURING BUILD
 from .header import LONG_VERSION_PY, get_root, get_config_from_root # --STRIP DURING BUILD
 from .get_versions import get_versions # --STRIP DURING BUILD
 from .from_file import write_to_version_file # --STRIP DURING BUILD
 
 
-def get_cmdclass(cmdclass=None):
+def get_cmdclass(cmdclass: Optional[Dict[str, Any]] = None):
     """Get the custom setuptools subclasses used by Versioneer.
 
     If the package uses a different cmdclass (e.g. one from numpy), it
@@ -32,16 +33,16 @@ def get_cmdclass(cmdclass=None):
 
     class cmd_version(Command):
         description = "report generated version string"
-        user_options = []
-        boolean_options = []
+        user_options: List[Tuple[str, str, str]] = []
+        boolean_options: List[str] = []
 
-        def initialize_options(self):
+        def initialize_options(self) -> None:
             pass
 
-        def finalize_options(self):
+        def finalize_options(self) -> None:
             pass
 
-        def run(self):
+        def run(self) -> None:
             vers = get_versions(verbose=True)
             print("Version: %s" % vers["version"])
             print(" full-revisionid: %s" % vers.get("full-revisionid"))
@@ -71,12 +72,12 @@ def get_cmdclass(cmdclass=None):
 
     # we override different "build_py" commands for both environments
     if 'build_py' in cmds:
-        _build_py = cmds['build_py']
+        _build_py: Any = cmds['build_py']
     else:
         from setuptools.command.build_py import build_py as _build_py
 
     class cmd_build_py(_build_py):
-        def run(self):
+        def run(self) -> None:
             root = get_root()
             cfg = get_config_from_root(root)
             versions = get_versions()
@@ -95,12 +96,12 @@ def get_cmdclass(cmdclass=None):
     cmds["build_py"] = cmd_build_py
 
     if 'build_ext' in cmds:
-        _build_ext = cmds['build_ext']
+        _build_ext: Any = cmds['build_ext']
     else:
         from setuptools.command.build_ext import build_ext as _build_ext
 
     class cmd_build_ext(_build_ext):
-        def run(self):
+        def run(self) -> None:
             root = get_root()
             cfg = get_config_from_root(root)
             versions = get_versions()
@@ -136,7 +137,7 @@ def get_cmdclass(cmdclass=None):
         #   ...
 
         class cmd_build_exe(_build_exe):
-            def run(self):
+            def run(self) -> None:
                 root = get_root()
                 cfg = get_config_from_root(root)
                 versions = get_versions()
@@ -165,7 +166,7 @@ def get_cmdclass(cmdclass=None):
             from py2exe.distutils_buildexe import py2exe as _py2exe  # type: ignore
 
         class cmd_py2exe(_py2exe):
-            def run(self):
+            def run(self) -> None:
                 root = get_root()
                 cfg = get_config_from_root(root)
                 versions = get_versions()
@@ -188,12 +189,12 @@ def get_cmdclass(cmdclass=None):
 
     # sdist farms its file list building out to egg_info
     if 'egg_info' in cmds:
-        _egg_info = cmds['egg_info']
+        _egg_info: Any = cmds['egg_info']
     else:
         from setuptools.command.egg_info import egg_info as _egg_info
 
     class cmd_egg_info(_egg_info):
-        def find_sources(self):
+        def find_sources(self) -> None:
             # egg_info.find_sources builds the manifest list and writes it
             # in one shot
             super().find_sources()
@@ -225,12 +226,12 @@ def get_cmdclass(cmdclass=None):
 
     # we override different "sdist" commands for both environments
     if 'sdist' in cmds:
-        _sdist = cmds['sdist']
+        _sdist: Any = cmds['sdist']
     else:
         from setuptools.command.sdist import sdist as _sdist
 
     class cmd_sdist(_sdist):
-        def run(self):
+        def run(self) -> None:
             versions = get_versions()
             self._versioneer_generated_versions = versions
             # unless we update this, the command will keep using the old
@@ -238,7 +239,7 @@ def get_cmdclass(cmdclass=None):
             self.distribution.metadata.version = versions["version"]
             return _sdist.run(self)
 
-        def make_release_tree(self, base_dir, files):
+        def make_release_tree(self, base_dir: str, files: List[str]) -> None:
             root = get_root()
             cfg = get_config_from_root(root)
             _sdist.make_release_tree(self, base_dir, files)

--- a/src/cmdclass.py
+++ b/src/cmdclass.py
@@ -127,7 +127,7 @@ def get_cmdclass(cmdclass=None):
     cmds["build_ext"] = cmd_build_ext
 
     if "cx_Freeze" in sys.modules:  # cx_freeze enabled?
-        from cx_Freeze.dist import build_exe as _build_exe
+        from cx_Freeze.dist import build_exe as _build_exe  # type: ignore
         # nczeczulin reports that py2exe won't like the pep440-style string
         # as FILEVERSION, but it can be used for PRODUCTVERSION, e.g.
         # setup(console=[{
@@ -160,9 +160,9 @@ def get_cmdclass(cmdclass=None):
 
     if 'py2exe' in sys.modules:  # py2exe enabled?
         try:
-            from py2exe.setuptools_buildexe import py2exe as _py2exe
+            from py2exe.setuptools_buildexe import py2exe as _py2exe  # type: ignore
         except ImportError:
-            from py2exe.distutils_buildexe import py2exe as _py2exe
+            from py2exe.distutils_buildexe import py2exe as _py2exe  # type: ignore
 
         class cmd_py2exe(_py2exe):
             def run(self):

--- a/src/from_file.py
+++ b/src/from_file.py
@@ -17,9 +17,10 @@ def get_versions():
 
 import json # --STRIP DURING BUILD
 import re # --STRIP DURING BUILD
+from typing import Any, Dict # --STRIP DURING BUILD
 from .header import NotThisMethod # --STRIP DURING BUILD
 
-def versions_from_file(filename):
+def versions_from_file(filename: str) -> Dict[str, Any]:
     """Try to determine the version from _version.py if present."""
     try:
         with open(filename) as f:
@@ -36,7 +37,7 @@ def versions_from_file(filename):
     return json.loads(mo.group(1))
 
 
-def write_to_version_file(filename, versions):
+def write_to_version_file(filename: str, versions: Dict[str, Any]) -> None:
     """Write the given version number to the given _version.py file."""
     contents = json.dumps(versions, sort_keys=True,
                           indent=1, separators=(",", ": "))

--- a/src/get_versions.py
+++ b/src/get_versions.py
@@ -1,4 +1,5 @@
 import os, sys # --STRIP DURING BUILD
+from typing import Any, Dict # --STRIP DURING BUILD
 from .header import HANDLERS, get_root, get_config_from_root # --STRIP DURING BUILD
 from .header import NotThisMethod # --STRIP DURING BUILD
 from .from_file import versions_from_file # --STRIP DURING BUILD
@@ -9,7 +10,7 @@ class VersioneerBadRootError(Exception):
     """The project root directory is unknown or missing key files."""
 
 
-def get_versions(verbose=False):
+def get_versions(verbose: bool = False) -> Dict[str, Any]:
     """Get the project version from whatever source is available.
 
     Returns dict with two keys: 'version' and 'full'.
@@ -24,7 +25,7 @@ def get_versions(verbose=False):
     assert cfg.VCS is not None, "please set [versioneer]VCS= in setup.cfg"
     handlers = HANDLERS.get(cfg.VCS)
     assert handlers, "unrecognized VCS '%s'" % cfg.VCS
-    verbose = verbose or cfg.verbose
+    verbose = verbose or bool(cfg.verbose)  # `bool()` used to avoid `None`
     assert cfg.versionfile_source is not None, \
         "please set versioneer.versionfile_source"
     assert cfg.tag_prefix is not None, "please set versioneer.tag_prefix"
@@ -85,6 +86,6 @@ def get_versions(verbose=False):
             "date": None}
 
 
-def get_version():
+def get_version() -> str:
     """Get the short version string for this project."""
     return get_versions()["version"]

--- a/src/git/install.py
+++ b/src/git/install.py
@@ -1,7 +1,9 @@
+import os # --STRIP DURING BUILD
 import sys # --STRIP DURING BUILD
+from typing import Optional # --STRIP DURING BUILD
 from subprocess_helper import run_command # --STRIP DURING BUILD
 
-def do_vcs_install(versionfile_source, ipy):
+def do_vcs_install(versionfile_source: str, ipy: Optional[str]) -> None:
     """Git-specific installation logic for Versioneer.
 
     For Git, this means creating/changing .gitattributes to mark _version.py

--- a/src/header.py
+++ b/src/header.py
@@ -20,6 +20,7 @@ import subprocess
 import sys
 from pathlib import Path
 from typing import Any, Callable, cast, Dict, List, Optional, Tuple, Union
+from typing import NoReturn
 import functools
 
 have_tomllib = True

--- a/src/header.py
+++ b/src/header.py
@@ -19,7 +19,7 @@ import re
 import subprocess
 import sys
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, cast, Dict, List, Optional, Tuple, Union
 import functools
 
 have_tomllib = True
@@ -36,8 +36,16 @@ from .get_versions import VersioneerBadRootError # --STRIP DURING BUILD
 class VersioneerConfig:
     """Container for Versioneer configuration parameters."""
 
+    VCS: str
+    style: str
+    tag_prefix: str
+    versionfile_source: str
+    versionfile_build: Optional[str]
+    parentdir_prefix: Optional[str]
+    verbose: Optional[bool]
 
-def get_root():
+
+def get_root() -> str:
     """Get the project root directory.
 
     We require that all commands are run from the project root, i.e. the
@@ -76,16 +84,16 @@ def get_root():
     return root
 
 
-def get_config_from_root(root):
+def get_config_from_root(root: str) -> VersioneerConfig:
     """Read the project setup.cfg file to determine Versioneer config."""
     # This might raise OSError (if setup.cfg is missing), or
     # configparser.NoSectionError (if it lacks a [versioneer] section), or
     # configparser.NoOptionError (if it lacks "VCS="). See the docstring at
     # the top of versioneer.py for instructions on writing your setup.cfg .
-    root = Path(root)
-    pyproject_toml = root / "pyproject.toml"
-    setup_cfg = root / "setup.cfg"
-    section = None
+    root_pth = Path(root)
+    pyproject_toml = root_pth / "pyproject.toml"
+    setup_cfg = root_pth / "setup.cfg"
+    section: Union[Dict[str, Any], configparser.SectionProxy, None] = None
     if pyproject_toml.exists() and have_tomllib:
         try:
             with open(pyproject_toml, 'rb') as fobj:
@@ -102,16 +110,25 @@ def get_config_from_root(root):
 
         section = parser["versioneer"]
 
+    # `cast`` really shouldn't be used, but its simplest for the
+    # common VersioneerConfig users at the moment. We verify against
+    # `None` values elsewhere where it matters
+
     cfg = VersioneerConfig()
     cfg.VCS = section['VCS']
     cfg.style = section.get("style", "")
-    cfg.versionfile_source = section.get("versionfile_source")
+    cfg.versionfile_source = cast(str, section.get("versionfile_source"))
     cfg.versionfile_build = section.get("versionfile_build")
-    cfg.tag_prefix = section.get("tag_prefix")
+    cfg.tag_prefix = cast(str, section.get("tag_prefix"))
     if cfg.tag_prefix in ("''", '""', None):
         cfg.tag_prefix = ""
     cfg.parentdir_prefix = section.get("parentdir_prefix")
-    cfg.verbose = section.get("verbose")
+    if isinstance(section, configparser.SectionProxy):
+        # Make sure configparser translates to bool
+        cfg.verbose = section.getboolean("verbose")
+    else:
+        cfg.verbose = section.get("verbose")
+
     return cfg
 
 
@@ -124,9 +141,9 @@ LONG_VERSION_PY: Dict[str, str] = {}
 HANDLERS: Dict[str, Dict[str, Callable]] = {}
 
 
-def register_vcs_handler(vcs, method):  # decorator
+def register_vcs_handler(vcs: str, method: str) -> Callable:  # decorator
     """Create decorator to mark a method as the handler of a VCS."""
-    def decorate(f):
+    def decorate(f: Callable) -> Callable:
         """Store f in HANDLERS[vcs][method]."""
         HANDLERS.setdefault(vcs, {})[method] = f
         return f

--- a/src/installer.py
+++ b/src/installer.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import sys, base64
+from typing import NoReturn
 
 VERSIONEER_b64 = """
 @VERSIONEER-INSTALLER@
@@ -13,7 +14,7 @@ VERSIONEER = base64.b64decode(VERSIONEER_b64.encode('ASCII'))
 
 
 # Stub overwritten by exec()
-def setup_command(): ...
+def setup_command() -> NoReturn: ...  # type: ignore
 
 # Make versioneer usable via import
 exec(VERSIONEER.decode(), globals())
@@ -33,7 +34,7 @@ def detect_installed_version() -> str:
     return "unknown version"
 
 
-def vendor():
+def vendor() -> None:
     """Install versioneer into current directory"""
     try:
         oldver = detect_installed_version()
@@ -47,7 +48,7 @@ def vendor():
     print(f"versioneer.py ({newver}) installed into local tree")
 
 
-def main():
+def main() -> NoReturn:
     usage = "Usage: versioneer install [--vendor|--no-vendor]"
     if len(sys.argv) < 2 or len(sys.argv) > 3:
         print(usage)

--- a/src/setupfunc.py
+++ b/src/setupfunc.py
@@ -1,6 +1,7 @@
 
 import configparser # --STRIP DURING BUILD
 import os, sys  # --STRIP DURING BUILD
+from typing import NoReturn, Optional  # --STRIP DURING BUILD
 from .header import get_config_from_root, get_root # --STRIP DURING BUILD
 from .header import LONG_VERSION_PY # --STRIP DURING BUILD
 from .git.install import do_vcs_install # --STRIP DURING BUILD
@@ -54,7 +55,7 @@ __version__ = {0}.get_versions()['version']
 """
 
 
-def do_setup():
+def do_setup() -> int:
     """Do main VCS-independent setup function for installing Versioneer."""
     root = get_root()
     try:
@@ -81,6 +82,7 @@ def do_setup():
 
     ipy = os.path.join(os.path.dirname(cfg.versionfile_source),
                        "__init__.py")
+    maybe_ipy: Optional[str] = ipy
     if os.path.exists(ipy):
         try:
             with open(ipy, "r") as f:
@@ -101,16 +103,16 @@ def do_setup():
             print(" %s unmodified" % ipy)
     else:
         print(" %s doesn't exist, ok" % ipy)
-        ipy = None
+        maybe_ipy = None
 
     # Make VCS-specific changes. For git, this means creating/changing
     # .gitattributes to mark _version.py for export-subst keyword
     # substitution.
-    do_vcs_install(cfg.versionfile_source, ipy)
+    do_vcs_install(cfg.versionfile_source, maybe_ipy)
     return 0
 
 
-def scan_setup_py():
+def scan_setup_py() -> int:
     """Validate the contents of setup.py against Versioneer's expectations."""
     found = set()
     setters = False
@@ -147,7 +149,7 @@ def scan_setup_py():
     return errors
 
 
-def setup_command():
+def setup_command() -> NoReturn:
     """Set up Versioneer and exit with appropriate error code."""
     errors = do_setup()
     errors += scan_setup_py()

--- a/tox.ini
+++ b/tox.ini
@@ -57,4 +57,4 @@ commands =
     pyflakes test
     flake8 git_version.py versioneer.py
     pycodestyle --max-line-length=88 git_version.py versioneer.py
-    !pypy3: mypy git_version.py versioneer.py src/installer.py
+    !pypy3: mypy git_version.py versioneer.py src/installer.py setup.py

--- a/tox.ini
+++ b/tox.ini
@@ -35,6 +35,7 @@ deps =
     pip>=20
     build
     tomli; python_version < "3.11"
+    types-setuptools
     !pypy3: mypy
 
 commands =
@@ -56,4 +57,4 @@ commands =
     pyflakes test
     flake8 git_version.py versioneer.py
     pycodestyle --max-line-length=88 git_version.py versioneer.py
-    !pypy3: mypy git_version.py
+    !pypy3: mypy git_version.py versioneer.py

--- a/tox.ini
+++ b/tox.ini
@@ -57,4 +57,4 @@ commands =
     pyflakes test
     flake8 git_version.py versioneer.py
     pycodestyle --max-line-length=88 git_version.py versioneer.py
-    !pypy3: mypy git_version.py versioneer.py
+    !pypy3: mypy git_version.py versioneer.py src/installer.py


### PR DESCRIPTION
This adds enough of the type checking, (and fixes a few minor type issues) for the entirety of the versioneer repository.

There are still better type checking things we could do, but this is a great start and should allow at least *some* type check abilities of dependent projects