### PR TITLE
Detect pyproject.toml as project root

### DIFF
--- a/src/header.py
+++ b/src/header.py
@@ -54,13 +54,23 @@ def get_root() -> str:
     """
     root = os.path.realpath(os.path.abspath(os.getcwd()))
     setup_py = os.path.join(root, "setup.py")
+    pyproject_toml = os.path.join(root, "pyproject.toml")
     versioneer_py = os.path.join(root, "versioneer.py")
-    if not (os.path.exists(setup_py) or os.path.exists(versioneer_py)):
+    if not (
+        os.path.exists(setup_py)
+        or os.path.exists(pyproject_toml)
+        or os.path.exists(versioneer_py)
+    ):
         # allow 'python path/to/setup.py COMMAND'
         root = os.path.dirname(os.path.realpath(os.path.abspath(sys.argv[0])))
         setup_py = os.path.join(root, "setup.py")
+        pyproject_toml = os.path.join(root, "pyproject.toml")
         versioneer_py = os.path.join(root, "versioneer.py")
-    if not (os.path.exists(setup_py) or os.path.exists(versioneer_py)):
+    if not (
+        os.path.exists(setup_py)
+        or os.path.exists(pyproject_toml)
+        or os.path.exists(versioneer_py)
+    ):
         err = ("Versioneer was unable to run the project root directory. "
                "Versioneer requires setup.py to be executed from "
                "its immediate directory (like 'python setup.py COMMAND'), "


### PR DESCRIPTION
Sometimes I use some package build tools which doesn't require setup.py, for example, pdm.backend. It doesn't need a setup.py, instead, it'll build wheel directly.
So with this pr, I can do this:
```toml
[tool.pdm.version]
source = "call"
getter = "versioneer:get_version"
```
Then when I run `pdm build`, pdm will read version from 'versioneer.get_version()'.
However, this doesn't work now because versioneer requires setup.py or versioneer.py to detect project root. It cannot find project root without setup.py or versioneer.py. When I using build-time dependency mode and "setup.py-less" build backend, either setup.py or versioneer.py doesn't exist, but the project root is still here! So this pull request made versioneer able to detect project root by pyproject.toml.