### PR TITLE
CI: End testing on the end-of-life Python 3.7

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest']
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', 'pypy3.9']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy3.9']
         shell: ['bash']
         include:
           - os: 'windows-latest'

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -18,6 +18,7 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: ['ubuntu-latest']
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', 'pypy3.9']

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@ This release adds formal support for Python 3.12.
 
 * MNT: Update `Cython` generated `.c` in `demoappext-setuptools` test project. by @Callek (#376)
 * CI: Add Python 3.12 to CI (initially at it's rc1 version). by @Callek (#376)
+* CI: End testing on the end-of-life Python 3.7. by @effigies (#378)
 
 ## Release 0.29 (7-Jul-2023)
 


### PR DESCRIPTION
Looking at #377, it was hard to tell whether 3.7 was the only affected runner. It may be some effect of running tests on an EOL Python, or there could be something deeper.

If it's just 3.7 failing, I would suggest just dropping it.

Closes #377.