### PR TITLE
Print warnings/informative messages to stderr not stdout to avoid interferring with setuptools etc

### DIFF
--- a/src/header.py
+++ b/src/header.py
@@ -89,7 +89,8 @@ def get_root() -> str:
         vsr_dir = os.path.normcase(os.path.splitext(versioneer_py)[0])
         if me_dir != vsr_dir and "VERSIONEER_PEP518" not in globals():
             print("Warning: build in %s is using versioneer.py from %s"
-                  % (os.path.dirname(my_path), versioneer_py))
+                  % (os.path.dirname(my_path), versioneer_py),
+                  file=sys.stderr)
     except NameError:
         pass
     return root
@@ -111,8 +112,8 @@ def get_config_from_root(root: str) -> VersioneerConfig:
                 pp = tomllib.load(fobj)
             section = pp['tool']['versioneer']
         except (tomllib.TOMLDecodeError, KeyError) as e:
-            print(f"Failed to load config from {pyproject_toml}: {e}")
-            print("Try to load it from setup.cfg")
+            print(f"Failed to load config from {pyproject_toml}: {e}", file=sys.stderr)
+            print("Try to load it from setup.cfg", file=sys.stderr)
     if not section:
         parser = configparser.ConfigParser()
         with open(setup_cfg) as cfg_file:


### PR DESCRIPTION
In datalad-container we use

    python setup.py --name

to programmatically determine main package name in the github action. Unfortunately recent upgrade of versioneer made it not usable due to issuing its mere informative messages to stdout which we expect to contain only target value

    ❯ python setup.py --name 2>/dev/null
    Failed to load config from /home/yoh/proj/datalad/datalad-container/pyproject.toml: 'versioneer'
    Try to load it from setup.cfg
    datalad_container

    ❯ echo $?
    0

I think it is more logical and consistent with other tools (e.g. git-annex, git etc) to output similar diagnostic logging messages to stderr.