### PR TITLE
Mypy Setuptools fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 import os, base64, tempfile, io
 from importlib import util as ilu
 from pathlib import Path
-from typing import List, Tuple
+from typing import List, Tuple, ClassVar
 from setuptools import setup, Command
 from setuptools.command.build_py import build_py
 from setuptools.command.develop import develop as _develop
@@ -85,7 +85,7 @@ def generate_versioneer_py() -> bytes:
 
 class make_versioneer(Command):
     description = "create standalone versioneer.py"
-    user_options: List[Tuple[str, str, str]] = []
+    user_options: ClassVar[List[Tuple[str, str, str]]] = []
     boolean_options: List[str] = []
     def initialize_options(self) -> None:
         pass
@@ -97,7 +97,7 @@ class make_versioneer(Command):
 
 class make_long_version_py_git(Command):
     description = "create standalone _version.py (for git)"
-    user_options: List[Tuple[str, str, str]] = []
+    user_options: ClassVar[List[Tuple[str, str, str]]] = []
     boolean_options: List[str] = []
     def initialize_options(self) -> None:
         pass

--- a/src/cmdclass.py
+++ b/src/cmdclass.py
@@ -1,5 +1,5 @@
 import os, sys # --STRIP DURING BUILD
-from typing import Any, Dict, List, Optional, Tuple # --STRIP DURING BUILD
+from typing import Any, ClassVar, Dict, List, Optional, Tuple # --STRIP DURING BUILD
 from .header import LONG_VERSION_PY, get_root, get_config_from_root # --STRIP DURING BUILD
 from .get_versions import get_versions # --STRIP DURING BUILD
 from .from_file import write_to_version_file # --STRIP DURING BUILD
@@ -33,7 +33,7 @@ def get_cmdclass(cmdclass: Optional[Dict[str, Any]] = None):
 
     class cmd_version(Command):
         description = "report generated version string"
-        user_options: List[Tuple[str, str, str]] = []
+        user_options: ClassVar[List[Tuple[str, str, str]]] = []
         boolean_options: List[str] = []
 
         def initialize_options(self) -> None:

--- a/src/header.py
+++ b/src/header.py
@@ -19,7 +19,7 @@ import re
 import subprocess
 import sys
 from pathlib import Path
-from typing import Any, Callable, cast, Dict, List, Optional, Tuple, Union
+from typing import Any, ClassVar, Callable, cast, Dict, List, Optional, Tuple, Union
 from typing import NoReturn
 import functools
 

--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,7 @@ deps =
     build
     tomli; python_version < "3.11"
     types-setuptools
-    py3{8,12}: mypy
+    py3{9,12}: mypy
 
 commands =
     pip --version
@@ -68,4 +68,4 @@ commands =
     pyflakes test
     flake8 git_version.py versioneer.py
     pycodestyle --max-line-length=88 git_version.py versioneer.py
-    py3{8,12}: mypy git_version.py versioneer.py src/installer.py setup.py
+    py3{9,12}: mypy git_version.py versioneer.py src/installer.py setup.py


### PR DESCRIPTION
The update to the latest `types-setuptools` breaks because it defines `user_options` as a `ClassVar`... fixed our typing.

This also has a ride-along that I missed when reviewing the "drop py3.8" logic